### PR TITLE
fix(theme): fix typos and improve i18n

### DIFF
--- a/packages/theme/src/node/i18n.ts
+++ b/packages/theme/src/node/i18n.ts
@@ -58,8 +58,8 @@ export const localesConfig: Record<string, HopeThemeI18nConfigItem> = {
       themeMode: "Theme Mode",
     },
     encrypt: {
-      title: "Please enter password",
-      errorHint: "Please enter the corrent password!",
+      title: "Please enter the password",
+      errorHint: "Please enter the correct password!",
     },
     error404: {
       hint: [


### PR DESCRIPTION
Pages made with this package that use encryption make the following prompt when asking for a password:

`Please enter password`

and when a user enters an incorrect password, the error message reads:

`Please enter the corrent password!`

I created a documentation for a customer using your wonderful package (thank you!). The customer is asking me to correct the grammar on the password prompt to:

`Please enter the password`

and correct the spelling from `corrent` to `correct`.

I believe I have done the changes on the right file. When you have time, could you incorporate this change?

Thanks again!