### PR TITLE
fix: 🐛 fix a typo for Breadcrumb in NormalPage.ts

### DIFF
--- a/packages/theme/src/client/components/NormalPage.ts
+++ b/packages/theme/src/client/components/NormalPage.ts
@@ -46,7 +46,7 @@ export default defineComponent({
           : [
               slots.top?.(),
               h(resolveComponent("BreadCrumb"), {
-                enable: breadcrumbEnable.value,
+                show: breadcrumbEnable.value,
                 icon: themeLocale.value.breadcrumbIcon,
                 iconPrefix: iconPrefix.value,
               }),


### PR DESCRIPTION
Configuring breadcrumb=false not work: there is a typo in NormalPage.ts,
change `enable` to `show`.

✅ Closes: #1479