### PR TITLE
cpx failed on OS X. Adding the quotes around the source arg fixed it

### DIFF
--- a/packages/comment2/package.json
+++ b/packages/comment2/package.json
@@ -41,7 +41,7 @@
     "demo:webpack-clean-serve": "vuepress-webpack dev __tests__/demo --clean-cache",
     "demo:webpack-serve": "vuepress-webpack dev __tests__/demo",
     "dev": "concurrently \"yarn dev:copy\" \"yarn dev:ts\"",
-    "dev:copy": "cpx src/client/**/*.{vue,scss} lib/client -w",
+    "dev:copy": "cpx 'src/client/**/*.{vue,scss}' lib/client -w",
     "dev:ts": "tsc -b tsconfig.build.json --watch"
   },
   "dependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,7 +37,7 @@
     "demo:webpack-clean-serve": "vuepress-webpack dev __tests__/demo --clean-cache",
     "demo:webpack-serve": "vuepress-webpack dev __tests__/demo",
     "dev": "concurrently \"yarn dev:copy\" \"yarn dev:ts\"",
-    "dev:copy": "cpx src/client/**/*.{vue,scss} lib/client -w",
+    "dev:copy": "cpx 'src/client/**/*.{vue,scss}' lib/client -w",
     "dev:ts": "tsc -b tsconfig.build.json --watch"
   },
   "dependencies": {

--- a/packages/components/src/client/components/TagInfo.ts
+++ b/packages/components/src/client/components/TagInfo.ts
@@ -37,6 +37,8 @@ export default defineComponent({
     const route = useRoute();
     const pageInfoLocale = useLocaleConfig(articleInfoLocales);
 
+    const tags = [...props.tag].sort()
+
     const colorMap = ref(
       Array(9)
         .fill(null)
@@ -52,7 +54,7 @@ export default defineComponent({
     });
 
     return (): VNode | null =>
-      props.tag.length
+      tags
         ? h(
             "span",
             {
@@ -64,7 +66,7 @@ export default defineComponent({
               h(
                 "ul",
                 { class: "tags-wrapper" },
-                props.tag.map(({ name, path }, index) =>
+                tags.map(({ name, path }, index) =>
                   h(
                     "li",
                     {
@@ -84,7 +86,7 @@ export default defineComponent({
               ),
               h("meta", {
                 property: "keywords",
-                content: props.tag.map(({ name }) => name).join(","),
+                content: tags.map(({ name }) => name).join(","),
               }),
             ]
           )

--- a/packages/components/src/client/components/TagInfo.ts
+++ b/packages/components/src/client/components/TagInfo.ts
@@ -37,8 +37,6 @@ export default defineComponent({
     const route = useRoute();
     const pageInfoLocale = useLocaleConfig(articleInfoLocales);
 
-    const tags = [...props.tag].sort()
-
     const colorMap = ref(
       Array(9)
         .fill(null)
@@ -54,7 +52,7 @@ export default defineComponent({
     });
 
     return (): VNode | null =>
-      tags
+      props.tag.length
         ? h(
             "span",
             {
@@ -66,7 +64,7 @@ export default defineComponent({
               h(
                 "ul",
                 { class: "tags-wrapper" },
-                tags.map(({ name, path }, index) =>
+                props.tag.map(({ name, path }, index) =>
                   h(
                     "li",
                     {
@@ -86,7 +84,7 @@ export default defineComponent({
               ),
               h("meta", {
                 property: "keywords",
-                content: tags.map(({ name }) => name).join(","),
+                content: props.tag.map(({ name }) => name).join(","),
               }),
             ]
           )

--- a/packages/copy-code2/package.json
+++ b/packages/copy-code2/package.json
@@ -39,7 +39,7 @@
     "demo:webpack-clean-serve": "vuepress-webpack dev __tests__/demo --clean-cache",
     "demo:webpack-serve": "vuepress-webpack dev __tests__/demo",
     "dev": "concurrently \"yarn dev:copy\" \"yarn dev:ts\"",
-    "dev:copy": "cpx src/client/**/*.{vue,scss} lib/client -w",
+    "dev:copy": "cpx 'src/client/**/*.{vue,scss}' lib/client -w",
     "dev:ts": "tsc -b tsconfig.build.json --watch"
   },
   "dependencies": {

--- a/packages/lightgallery/package.json
+++ b/packages/lightgallery/package.json
@@ -39,7 +39,7 @@
     "demo:webpack-clean-serve": "vuepress-webpack dev __tests__/demo --clean-cache",
     "demo:webpack-serve": "vuepress-webpack dev __tests__/demo",
     "dev": "concurrently \"yarn dev:copy\" \"yarn dev:ts\"",
-    "dev:copy": "cpx src/client/**/*.{vue,scss} lib/client -w",
+    "dev:copy": "cpx 'src/client/**/*.{vue,scss}' lib/client -w",
     "dev:ts": "tsc -b tsconfig.build.json --watch"
   },
   "dependencies": {

--- a/packages/md-enhance/package.json
+++ b/packages/md-enhance/package.json
@@ -47,7 +47,7 @@
     "demo:webpack-clean-serve": "vuepress-webpack dev __tests__/demo --clean-cache",
     "demo:webpack-serve": "vuepress-webpack dev __tests__/demo",
     "dev": "concurrently \"yarn dev:copy\" \"yarn dev:ts\"",
-    "dev:copy": "cpx src/client/**/*.{vue,css,scss,eot,woff,ttf} lib/client -w",
+    "dev:copy": "cpx 'src/client/**/*.{vue,css,scss,eot,woff,ttf}' lib/client -w",
     "dev:ts": "tsc -b tsconfig.build.json --watch"
   },
   "dependencies": {

--- a/packages/photo-swipe/package.json
+++ b/packages/photo-swipe/package.json
@@ -41,7 +41,7 @@
     "demo:webpack-clean-serve": "vuepress-webpack dev __tests__/demo --clean-cache",
     "demo:webpack-serve": "vuepress-webpack dev __tests__/demo",
     "dev": "concurrently \"yarn dev:copy\" \"yarn dev:ts\"",
-    "dev:copy": "cpx src/client/**/*.{vue,scss} lib/client -w",
+    "dev:copy": "cpx 'src/client/**/*.{vue,scss}' lib/client -w",
     "dev:ts": "tsc -b tsconfig.build.json --watch"
   },
   "dependencies": {

--- a/packages/pwa2/package.json
+++ b/packages/pwa2/package.json
@@ -40,7 +40,7 @@
     "demo:webpack-clean-serve": "vuepress-webpack dev __tests__/demo --clean-cache",
     "demo:webpack-serve": "vuepress-webpack dev __tests__/demo",
     "dev": "concurrently \"yarn dev:copy\" \"yarn dev:ts\"",
-    "dev:copy": "cpx src/client/**/*.{vue,scss} lib/client -w",
+    "dev:copy": "cpx 'src/client/**/*.{vue,scss}' lib/client -w",
     "dev:ts": "tsc -b tsconfig.build.json --watch"
   },
   "dependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,7 +33,7 @@
     "build": "rollup -c",
     "clean": "rimraf ./lib ./*.tsbuildinfo",
     "dev": "concurrently \"yarn dev:copy\" \"yarn dev:ts\"",
-    "dev:copy": "cpx src/client/**/*.{vue,scss} lib/client -w",
+    "dev:copy": "cpx 'src/client/**/*.{vue,scss}' lib/client -w",
     "dev:ts": "tsc -b tsconfig.build.json --watch"
   },
   "dependencies": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build": "yarn build:ts && yarn build:copy",
-    "build:copy": "cpx src/client/**/*.{css,scss,jpg,vue} lib/client",
+    "build:copy": "cpx 'src/client/**/*.{css,scss,jpg,vue}' lib/client",
     "build:ts": "tsc -b tsconfig.release.json",
     "clean": "rimraf ./lib ./*.tsbuildinfo",
     "dev": "concurrently \"yarn dev:copy\" \"yarn dev:ts\"",


### PR DESCRIPTION
~~~
vuepress-plugin-md-enhance: created ./lib/client/SlidePage.d.ts in 2.8s
vuepress-theme-hope: $ yarn build:ts && yarn build:copy
vuepress-theme-hope: $ tsc -b tsconfig.release.json
vuepress-theme-hope: $ cpx src/client/**/*.{css,scss,jpg,vue} lib/client
vuepress-theme-hope: Usage: cpx <source> <dest> [options]
vuepress-theme-hope:     cpx2: Copy files, watching for changes.
vuepress-theme-hope:         <source>  The glob of target files.
vuepress-theme-hope:         <dest>    The path of a destination directory.
 :      :     :
vuepress-theme-hope: error Command failed with exit code 1.
vuepress-theme-hope: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
vuepress-theme-hope: error Command failed with exit code 1.
vuepress-theme-hope: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
lerna ERR! yarn run build exited 1 in 'vuepress-theme-hope'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
~~~