### PR TITLE
refactor(theme): add gap between navbar and blog-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist/
 
 # Coverage Files
 coverage/
+
+# macOS
+.DS_Store

--- a/packages/theme/src/client/module/blog/styles/info-panel.scss
+++ b/packages/theme/src/client/module/blog/styles/info-panel.scss
@@ -8,20 +8,20 @@
 
   .page & {
     position: sticky;
-    top: var(--navbar-height);
+    top: calc(var(--navbar-height) + 0.75rem);
 
     flex: 0 0 300px;
 
     box-sizing: border-box;
 
     height: auto;
-    margin-top: 0.75rem;
+    margin-top: 0;
     margin-bottom: 0.75rem;
 
     transition: all 0.3s;
 
     @media (max-width: hope-config.$pad) {
-      top: var(--navbar-mobile-height);
+      top: calc(var(--navbar-mobile-height) + 0.75rem);
     }
 
     @media (max-width: hope-config.$mobile) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1180450/162768176-9dadde46-9390-4b7a-a251-655bcd57a267.png)

After:
![image](https://user-images.githubusercontent.com/1180450/162767696-e82a0b8b-29b6-4ace-bf4e-1c344cc0a777.png)
