### PR TITLE
repository icon of navibar

### DIFF
--- a/docs/theme/src/config/theme/layout.md
+++ b/docs/theme/src/config/theme/layout.md
@@ -51,6 +51,13 @@ Navbar logo in darkmode, should be absolute path relative to `.vuepress/public` 
 
 Repository link
 
+### repoType
+
+- Type: `"Github" | "Gitlab" | "Bitbucket" | "Gitee" | null;`
+- Required: No
+
+Repository type, decides the icon of the repository link. It's automatically recognizes based on links by default.
+
 ### repoDisplay
 
 - Type: `boolean`

--- a/docs/theme/src/zh/config/theme/layout.md
+++ b/docs/theme/src/zh/config/theme/layout.md
@@ -51,6 +51,13 @@ tag:
 
 仓库配置，用于在导航栏中显示仓库链接。
 
+### repoType
+
+- 类型: `"Github" | "Gitlab" | "Bitbucket" | "Gitee" | null;`
+- 必填: 否
+
+仓库类型配置，对应不同的仓库链接图标。默认根据repo链接自动识别。
+
 ### repoDisplay
 
 - 类型: `boolean`

--- a/packages/theme/src/client/module/navbar/components/RepoLink.ts
+++ b/packages/theme/src/client/module/navbar/components/RepoLink.ts
@@ -35,7 +35,7 @@ export default defineComponent({
               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               h(resolveComponent(`${repo.value.type}Icon`), {
                 style: {
-                  width: "1.25rem",
+                  width: "2rem",
                   height: "1.25rem",
                   verticalAlign: "middle",
                 },

--- a/packages/theme/src/client/module/navbar/composables/repoLink.ts
+++ b/packages/theme/src/client/module/navbar/composables/repoLink.ts
@@ -21,7 +21,11 @@ export const useNavbarRepo = (): ComputedRef<RepoConfig | null> => {
 
   const repo = computed(() => themeLocale.value.repo);
   const repoType = computed(() =>
-    repo.value ? resolveRepoType(repo.value) : null
+    themeLocale.value.repoType
+      ? (themeLocale.value.repoType as RepoType)
+      : repo.value
+      ? resolveRepoType(repo.value)
+      : null
   );
 
   const repoLink = computed(() => {

--- a/packages/theme/src/shared/options/layout/navbar.ts
+++ b/packages/theme/src/shared/options/layout/navbar.ts
@@ -67,6 +67,12 @@ export interface HopeThemeNavbarLocaleOptions {
    * 仓库链接
    */
   repo?: string | null;
+  /**
+   * Repository Type
+   *
+   * 仓库类型
+   */
+  repoType?: "Github" | "Gitlab" | "Bitbucket" | "Gitee" | null;
 
   /**
    * Whether display repo link in navbar.


### PR DESCRIPTION
change the width of the "Source" icon or it will not show completely.
Add support for specifying repository type. #1679 