### PR TITLE
chore: add scopeComplete for cz-git

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,7 +1,16 @@
+const { execSync } = require('child_process')
 const fs = require("fs");
 const path = require("path");
 
 const packages = fs.readdirSync(path.resolve(__dirname, "packages"));
+
+const scopeComplete = execSync("git status --porcelain || true")
+  .toString()
+  .trim()
+  .split("\n")
+  .find((r) => ~r.indexOf("M  packages"))
+  ?.replace(/\//g, "%%")
+  ?.match(/packages%%((\w|-)*)/)?.[1];
 
 /** @type {import('cz-git').UserConfig} */
 module.exports = {
@@ -10,7 +19,8 @@ module.exports = {
     "scope-enum": [2, "always", ["demo", "release", ...packages]],
   },
   prompt: {
-    customScopesAlign: "top",
+    defaultScope: scopeComplete,
+    customScopesAlign: !scopeComplete ? "top" : "bottom",
     allowCustomIssuePrefixs: false,
     allowEmptyIssuePrefixs: false,
   },

--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,6 +1,6 @@
-const { execSync } = require('child_process')
 const fs = require("fs");
 const path = require("path");
+const { execSync } = require("child_process");
 
 const packages = fs.readdirSync(path.resolve(__dirname, "packages"));
 


### PR DESCRIPTION
- Mr. hope, I recently got inspiration from vuepress's pr https://github.com/vuepress/vuepress-next/pull/907 . Get the path to match the scope through the git status buffer.
- so that when you use cz-git, the matching items will be automatically set to the top.
- so, I can't wait for Mr.hope to try it out, just f**ck try and use it and enjoy it.

demo:
![demo](https://user-images.githubusercontent.com/40693636/170414162-fb7d413c-19bf-450d-8894-d7dba9ad9bf6.gif)
