### PR TITLE
docs: fix config typos

### DIFF
--- a/docs/theme/src/config/frontmatter/info.md
+++ b/docs/theme/src/config/frontmatter/info.md
@@ -80,7 +80,7 @@ Set the writing time of the current page.
 
 Set the category of the current page.
 
-## tags
+## tag
 
 - Type: `string | string []`
 - Required: No

--- a/docs/theme/src/zh/config/frontmatter/info.md
+++ b/docs/theme/src/zh/config/frontmatter/info.md
@@ -80,7 +80,7 @@ type Author = string | string[] | AuthorInfo | AuthorInfo[];
 
 分类。
 
-## tags
+## tag
 
 - 类型: `string | string[]`
 - 必填: 否


### PR DESCRIPTION
tags has deprecated, should use tag instead.