### PR TITLE
Fix typo

### DIFF
--- a/packages/create/src/config/i18n.ts
+++ b/packages/create/src/config/i18n.ts
@@ -109,7 +109,7 @@ export const i18n: Record<Lang, CreateI18n> = {
       name: "Your project name",
       version: "Your project version",
       description: "Your project description",
-      license: "Your project lincense",
+      license: "Your project license",
     },
 
     hint: {


### PR DESCRIPTION
Fix typo `lincense` -> `license` in English i8n.