### PR TITLE
fix: ja-JP locale missing in config

### DIFF
--- a/packages/shared/src/node/utils/dayjs/index.ts
+++ b/packages/shared/src/node/utils/dayjs/index.ts
@@ -5,7 +5,6 @@ import { default as timezone } from "dayjs/plugin/timezone.js";
 import { default as utc } from "dayjs/plugin/utc.js";
 import { loadDeLocale } from "./de.js";
 import { loadDeAtLocale } from "./de-at.js";
-
 import { loadEnLocale } from "./en.js";
 import { loadEsLocale } from "./es.js";
 import { loadFrLocale } from "./fr.js";
@@ -17,6 +16,7 @@ import { loadUkLocale } from "./uk.js";
 import { loadViLocale } from "./vi.js";
 import { loadZhLocale } from "./zh.js";
 import { loadZhTWLocale } from "./zh-tw.js";
+import { loadJaLocale } from "./ja.js";
 
 dayjs.extend(localizedFormat);
 dayjs.extend(objectSupport);
@@ -36,6 +36,7 @@ loadUkLocale(dayjs);
 loadViLocale(dayjs);
 loadZhLocale(dayjs);
 loadZhTWLocale(dayjs);
+loadJaLocale(dayjs);
 
 export const getLocale = (lang = "en"): string => {
   const langcode = lang.toLowerCase();
@@ -55,6 +56,7 @@ export const getLocale = (lang = "en"): string => {
       "vi",
       "zh",
       "zh-tw",
+      "ja",
     ].includes(langcode)
   )
     return langcode;
@@ -68,6 +70,7 @@ export const getLocale = (lang = "en"): string => {
   if (langcode === "sk-sk") return "sk";
   if (langcode === "vi-vn") return "vi";
   if (langcode === "zh-cn") return "zh";
+  if (langcode === "ja-jp") return "ja";
 
   console.warn(`${lang} locale missing in config`);
 

--- a/packages/shared/src/node/utils/dayjs/ja.ts
+++ b/packages/shared/src/node/utils/dayjs/ja.ts
@@ -1,0 +1,62 @@
+// Japanese [ja]
+import type { default as dayjs } from "dayjs";
+import type { Locale } from "./locale.js";
+
+const locale: Locale = {
+  name: "ja-jp",
+  weekdays: "日曜日_月曜日_火曜日_水曜日_木曜日_金曜日_土曜日".split("_"),
+  weekdaysShort: "日曜_月曜_火曜_水曜_木曜_金曜_土曜".split("_"),
+  weekdaysMin: "日_月_火_水_木_金_土".split("_"),
+  months:
+    "一月_二月_三月_四月_五月_六月_七月_八月_九月_十月_十一月_十二月".split(
+      "_"
+    ),
+  monthsShort: "1月_2月_3月_4月_5月_6月_7月_8月_9月_10月_11月_12月".split("_"),
+  ordinal: (n) => `${n}日`,
+  weekStart: 1,
+  yearStart: 4,
+  formats: {
+    LT: "HH:mm",
+    LTS: "HH:mm:ss",
+    L: "YYYY/MM/DD",
+    LL: "YYYY年M月D日",
+    LLL: "YYYY年M月D日Ah時mm分",
+    LLLL: "YYYY年M月D日ddddAh時mm分",
+    l: "YYYY/M/D",
+    ll: "YYYY年M月D日",
+    lll: "YYYY年M月D日 HH:mm",
+    llll: "YYYY年M月D日dddd HH:mm",
+  },
+  relativeTime: {
+    future: "%s以内",
+    past: "%s前",
+    s: "数秒",
+    m: "1 分",
+    mm: "%d 分",
+    h: "1 時間",
+    hh: "%d 時間",
+    d: "1 日",
+    dd: "%d 日",
+    M: "1 ヶ月",
+    MM: "%d ヶ月",
+    y: "1 年",
+    yy: "%d 年",
+  },
+  meridiem: (hour, minute) => {
+    const hm = hour * 100 + minute;
+
+    return hm < 600
+      ? "朝"
+      : hm < 1200
+      ? "午前"
+      : hm < 1800
+      ? "午後"
+      : hm < 2000
+      ? "晚"
+      : "夜";
+  },
+};
+
+export const loadJaLocale = (extendeddayjs: typeof dayjs): void => {
+  extendeddayjs.locale("ja", locale);
+};


### PR DESCRIPTION
Fix the 'ja-JP locale missing in config' warning message when using Japanese resources, please review it.

Above.