### PR TITLE
fix: update blog2 excerpt example

### DIFF
--- a/demo/blog2/src/.vuepress/config.ts
+++ b/demo/blog2/src/.vuepress/config.ts
@@ -49,12 +49,18 @@ export default defineUserConfig({
         date: frontmatter.date || null,
         category: frontmatter.category || [],
         tag: frontmatter.tag || [],
-        excerpt: data?.excerpt || "",
+        excerpt:
+          // support manually set excerpt through frontmatter
+          typeof frontmatter.excerpt === "string"
+            ? frontmatter.excerpt
+            : data?.excerpt || "",
       }),
 
-      // If the user sets excerpt or description in frontmatter, the summary information will be displayed
+      // generate excerpt for all pages excerpt those users choose to disable
       excerptFilter: ({ frontmatter }) =>
-        Boolean(frontmatter?.excerpt || frontmatter?.description),
+        !frontmatter["home"] &&
+        frontmatter["excerpt"] !== false &&
+        typeof frontmatter["excerpt"] !== "string",
 
       category: [
         {

--- a/demo/blog2/src/.vuepress/config.ts
+++ b/demo/blog2/src/.vuepress/config.ts
@@ -43,14 +43,18 @@ export default defineUserConfig({
         filePathRelative ? filePathRelative.startsWith("posts/") : false,
 
       // getting article info
-      getInfo: ({ frontmatter, title, excerpt }) => ({
+      getInfo: ({ frontmatter, title, data }) => ({
         title,
         author: frontmatter.author || "",
         date: frontmatter.date || null,
         category: frontmatter.category || [],
         tag: frontmatter.tag || [],
-        excerpt,
+        excerpt: data?.excerpt || "",
       }),
+
+      // If the user sets excerpt or description in frontmatter, the summary information will be displayed
+      excerptFilter: ({ frontmatter }) =>
+        Boolean(frontmatter?.excerpt || frontmatter?.description),
 
       category: [
         {

--- a/demo/blog2/src/posts/sticky.md
+++ b/demo/blog2/src/posts/sticky.md
@@ -5,6 +5,7 @@ category:
 tag:
   - tag E
 sticky: true
+excerpt: <p>A sticky article demo.</p>
 ---
 
 # Sticky Article

--- a/demo/blog2/src/posts/sticky2.md
+++ b/demo/blog2/src/posts/sticky2.md
@@ -5,12 +5,11 @@ category:
 tag:
   - tag E
 sticky: 10
-excerpt: true
 ---
 
 # Sticky Article with Higher Priority
 
-excerpt info
+Excerpt information which is added manually.
 
 <!-- more -->
 

--- a/demo/blog2/src/posts/sticky2.md
+++ b/demo/blog2/src/posts/sticky2.md
@@ -5,9 +5,14 @@ category:
 tag:
   - tag E
 sticky: 10
+excerpt: true
 ---
 
 # Sticky Article with Higher Priority
+
+excerpt info
+
+<!-- more -->
 
 ## Heading 2
 

--- a/docs/blog2/src/guide.md
+++ b/docs/blog2/src/guide.md
@@ -115,14 +115,14 @@ export default {
         return true;
       },
 
-      getInfo: ({ excerpt, frontmatter, git = {} }) => {
+      getInfo: ({ frontmatter, git = {}, data = {} }) => {
         // getting page info
         const info: Record<string, any> = {
           author: frontmatter.author || "",
           categories: frontmatter.categories || [],
           date: frontmatter.date || git.createdTime || null,
           tags: frontmatter.tags || [],
-          excerpt: page.excerpt,
+          excerpt: data.excerpt || "",
         };
 
         return info;

--- a/docs/blog2/src/zh/guide.md
+++ b/docs/blog2/src/zh/guide.md
@@ -110,14 +110,14 @@ export default {
         return true;
       },
 
-      getInfo: ({ excerpt, frontmatter, git = {} }) => {
+      getInfo: ({ frontmatter, git = {}, data = {} }) => {
         // 获取页面信息
         const info: Record<string, any> = {
           author: frontmatter.author || "",
           categories: frontmatter.categories || [],
           date: frontmatter.date || git.createdTime || null,
           tags: frontmatter.tags || [],
-          excerpt: page.excerpt,
+          excerpt: data.excerpt || "",
         };
 
         return info;


### PR DESCRIPTION
vuepress-next: excerpt has been removed from page object and page data([a27bc24](https://github.com/vuepress/vuepress-next/commit/a27bc246602214970a12b0222d8bdbc49339cf03))
update the use example of excerpt in demo/blog2