### PR TITLE
Add German language support

### DIFF
--- a/packages/comment2/src/node/locales.ts
+++ b/packages/comment2/src/node/locales.ts
@@ -17,9 +17,14 @@ export const walineLocales: WalineLocaleConfig = {
     placeholder: "請留言。(填寫信箱可在被回覆時收到郵件提醒)",
   },
 
+  "/de/": {
+    placeholder:
+      "Schreibe ein Kommentar (Geben Sie die E-Mail-Adresse ein, um eine E-Mail-Benachrichtigung zu erhalten, wenn Sie eine Antwort erhalten)",
+  },
+
   "/de-at/": {
     placeholder:
-      "Schreibe ein Kommentar (Geben Sie die E-Mail-Adresse ein, um eine E-Mail-Benachrichtigung zu erhalten, wenn Sie geantwortet werden)",
+      "Schreibe ein Kommentar (Geben Sie die E-Mail-Adresse ein, um eine E-Mail-Benachrichtigung zu erhalten, wenn Sie eine Antwort erhalten)",
   },
 
   "/vi/": {

--- a/packages/components/src/node/locales/backToTop.ts
+++ b/packages/components/src/node/locales/backToTop.ts
@@ -13,6 +13,10 @@ export const backToTopLocales: BackToTopLocaleConfig = {
     backToTop: "返回頂部",
   },
 
+  "/de/": {
+    backToTop: "Zurück nach oben.",
+  },
+
   "/de-at/": {
     backToTop: "Zurück nach oben.",
   },

--- a/packages/components/src/node/locales/catalog.ts
+++ b/packages/components/src/node/locales/catalog.ts
@@ -13,6 +13,10 @@ export const catalogLocales: CatalogLocaleConfig = {
     title: "目錄",
   },
 
+  "/de/": {
+    title: "Katalog",
+  },
+
   "/de-at/": {
     title: "Katalog",
   },

--- a/packages/components/src/node/locales/pdf.ts
+++ b/packages/components/src/node/locales/pdf.ts
@@ -13,6 +13,10 @@ export const pdfLocaleConfig: PDFLocaleConfig = {
     hint: "<p>此瀏覽器不支援嵌入式 PDF。請下載 PDF 查看：<a href='[url]' target='_blank'>下載 PDF</a></p>",
   },
 
+  "/de/": {
+    hint: "<p>Dieser Browser unterstützt das Einbetten von PDFs nicht. Laden Sie die PDF herunter, um sie anzuzeigen: <a href='[url]' target='_blank'>PDF herunterladen</a></p>",
+  },
+
   "/de-at/": {
     hint: "<p>Dieser Browser unterstützt das Einbetten von PDFs nicht. Laden Sie die PDF herunter, um sie anzuzeigen: <a href='[url]' target='_blank'>PDF herunterladen</a></p>",
   },

--- a/packages/copy-code2/src/node/locales.ts
+++ b/packages/copy-code2/src/node/locales.ts
@@ -20,6 +20,12 @@ export const copyCodeLocales: CopyCodeLocaleConfig = {
     hint: "複製成功",
   },
 
+  "/de/": {
+    copy: "Kopiere den Code.",
+    copied: "Kopiert",
+    hint: "Kopieren erfolgreich",
+  },
+
   "/de-at/": {
     copy: "Kopiere den Code.",
     copied: "Kopierter",

--- a/packages/copyright2/src/node/locales.ts
+++ b/packages/copyright2/src/node/locales.ts
@@ -73,4 +73,16 @@ export const copyrightLocales: CopyrightLocaleConfig = {
     license: "Lisenssi :license",
     link: ":link",
   },
+
+  "/de/": {
+    author: "Copyright by :author",
+    license: "Lizenziert unter :license",
+    link: ":link",
+  },
+
+  "/de-AT/": {
+    author: "Copyright by :author",
+    license: "Lizenziert unter :license",
+    link: ":link",
+  },
 };

--- a/packages/md-enhance/src/node/locales.ts
+++ b/packages/md-enhance/src/node/locales.ts
@@ -28,6 +28,15 @@ export const markdownEnhanceLocales: MarkdownEnhanceLocaleConfig = {
     details: "詳情",
   },
 
+  "/de/": {
+    info: "Information",
+    note: "Notiz",
+    tip: "Tips",
+    warning: "Warnung",
+    danger: "Gefahr",
+    details: "Details",
+  },
+
   "/de-at/": {
     info: "Information",
     note: "Note",

--- a/packages/photo-swipe/src/node/locales.ts
+++ b/packages/photo-swipe/src/node/locales.ts
@@ -28,6 +28,15 @@ export const photoSwipeLocales: PhotoSwipeLocaleConfig = {
     arrowNext: "下一個 (右箭頭)",
   },
 
+  "/de/": {
+    close: "Schließen",
+    download: "Download",
+    fullscreen: "Vollbild aktivieren",
+    zoom: "Rein / rauszoomen",
+    arrowPrev: "Zurück (Pfeil links)",
+    arrowNext: "Weiter (Pfeil rechts)",
+  },
+
   "/de-at/": {
     close: "Schließen",
     download: "Download",

--- a/packages/pwa2/src/node/locales.ts
+++ b/packages/pwa2/src/node/locales.ts
@@ -47,6 +47,21 @@ export const pwaLocales: PWALocaleConfig = {
     update: "新内容已就绪",
   },
 
+  "/de/": {
+    install: "Installieren",
+    iOSInstall: "Drucke den Share-Button und dann 'zu Homescreen hinzufügen'",
+    cancel: "Abbrechen",
+    close: "Schließen",
+    prevImage: "Vorheriges Bild",
+    nextImage: "Nächstes Bild",
+    desc: "Berschreibung",
+    feature: "Funktionen",
+    explain:
+      "Diese App kann auf Ihrem PC oder Mobilgerät installiert werden. Dadurch sieht diese Web-App aus und verhält sich wie jede andere installierte App. Sie finden sie in Ihren App-Listen und können sie an den Startbildschirm, die Startmenüs oder die Taskleisten anheften. Diese installierte Web-App kann auch sicher mit anderen Apps und Ihrem Betriebssystem interagieren.",
+    hint: "Neuer Inhalt gefunden.",
+    update: "Neue Inhalte sind verfügbar.",
+  },
+
   "/de-at/": {
     install: "Installieren",
     iOSInstall: "Drucke den Share-Button und dan 'zu Homescreen hinzufügen'",

--- a/packages/reading-time2/src/node/locales.ts
+++ b/packages/reading-time2/src/node/locales.ts
@@ -22,6 +22,12 @@ export const readingTimeLocales: ReadingTimeLocaleConfig = {
     time: "大约 $time 分鐘",
   },
 
+  "/de/": {
+    word: "Ungefähr $word Wörter",
+    less1Minute: "Weniger als eine Minute",
+    time: "Ungefähr $time min",
+  },
+
   "/de-at/": {
     word: "Um die $word Wörter",
     less1Minute: "Weniger als eine Minute",

--- a/packages/search-pro/src/node/locales.ts
+++ b/packages/search-pro/src/node/locales.ts
@@ -41,6 +41,19 @@ export const searchProLocales: SearchProLocaleConfig = {
     loading: "正在加載搜索索引...",
   },
 
+  "/de/": {
+    cancel: "Abbrechen",
+    placeholder: "Suche",
+    search: "Suche",
+    select: "auswählen",
+    navigate: "wechseln",
+    exit: "schließen",
+    history: "Suchverlauf",
+    emptyHistory: "Suchverlauf leeren",
+    emptyResult: "Keine Ergebnisse gefunden",
+    loading: "Suchindex wird geladen...",
+  },
+
   "/de-at/": {
     cancel: "Abbrechen",
     placeholder: "Suche",

--- a/packages/shared/src/node/locales/config.ts
+++ b/packages/shared/src/node/locales/config.ts
@@ -3,6 +3,7 @@ import type { HopeLang } from "./types.js";
 
 export const lang2PathConfig = {
   "de-AT": "/de-at/",
+  "de-DE": "/de/",
   "en-US": "/en/",
   "es-ES": "/es/",
   "fi-FI": "/fi/",

--- a/packages/theme/src/node/locales/deAT.ts
+++ b/packages/theme/src/node/locales/deAT.ts
@@ -1,10 +1,10 @@
 import type { ThemeLocaleData } from "../../shared/index.js";
 
-export const deLocale: ThemeLocaleData = {
-  lang: "de",
+export const deATLocale: ThemeLocaleData = {
+  lang: "de-AT",
 
   navbarLocales: {
-    langName: "Deutsch",
+    langName: "Deutsch (Österreich)",
     selectLangAriaLabel: "Sprache wählen",
   },
 
@@ -17,9 +17,9 @@ export const deLocale: ThemeLocaleData = {
     tag: "Tag",
     readingTime: "Lesezeit",
     words: "Wörter",
-    toc: "Auf dieser Seite",
-    prev: "Vorherige",
-    next: "Nächste",
+    toc: "On This Page",
+    prev: "Prev",
+    next: "Next",
     lastUpdated: "Zuletzt geändert",
     contributors: "Mitwirkende",
     editLink: "Diese Seite barbeiten",
@@ -38,8 +38,8 @@ export const deLocale: ThemeLocaleData = {
   },
 
   paginationLocales: {
-    prev: "Vorherige",
-    next: "Nächste",
+    prev: "Vorheriges",
+    next: "Nächstes",
     navigate: "Springe zu",
     action: "Los",
     errorText: "Bitte gib eine Nummer zwischen 1 und $page ein!",
@@ -48,13 +48,13 @@ export const deLocale: ThemeLocaleData = {
   outlookLocales: {
     themeColor: "Design-Farbe",
     darkmode: "Design-Modus",
-    fullscreen: "Vollbild",
+    fullscreen: "Full Screen",
   },
 
   encryptLocales: {
-    iconLabel: "Seite verschlüsselt",
-    placeholder: "Passwort eingeben",
-    remember: "Passwort merken",
+    iconLabel: "Page Encrypted",
+    placeholder: "Entre a senha",
+    remember: "Remember password",
     errorHint: "Bitte das korrekte Passwort eingeben!",
   },
 
@@ -68,6 +68,6 @@ export const deLocale: ThemeLocaleData = {
     ],
     back: "Zurück",
     home: "Zur Startseite",
-    openInNewWindow: "In neuem Fenster öffnen",
+    openInNewWindow: "Open in new window",
   },
 };

--- a/packages/theme/src/node/locales/index.ts
+++ b/packages/theme/src/node/locales/index.ts
@@ -1,5 +1,6 @@
 import { brLocale } from "./br.js";
 import { deLocale } from "./de.js";
+import { deATLocale } from "./deAT.js";
 import { enLocale } from "./en.js";
 import { esLocale } from "./es.js";
 import { fiLocale } from "./fi.js";
@@ -23,7 +24,9 @@ export const themeLocalesData: Record<string, ThemeLocaleData> = {
 
   "/zh-tw/": zhTWLocale,
 
-  "/de-at/": deLocale,
+  "/de/": deLocale,
+
+  "/de-at/": deATLocale,
 
   "/vi/": viLocale,
 


### PR DESCRIPTION
Hello,

this pull request adds german language support.
The current de-AT is not usable in Germany.
de-AT = German (Austria)
de-DE or just de = German (Germany)

Most words are the same, but in the month names are different. So we need a different language setting.