### PR TITLE
fix: fix importing sitemap template

### DIFF
--- a/packages/sitemap2/package.json
+++ b/packages/sitemap2/package.json
@@ -33,7 +33,7 @@
   "types": "lib/node/index.d.ts",
   "files": [
     "lib",
-    "template"
+    "templates"
   ],
   "scripts": {
     "build": "rollup -c rollup.config.ts --configPlugin esbuild",


### PR DESCRIPTION
<img width="1143" alt="image" src="https://user-images.githubusercontent.com/5698350/212783338-fe486500-0adb-42e3-9acb-59294493542b.png">

Looks like vuepress-plugin-sitemap2@2.0.0-beta.162 is broken