### PR TITLE
docs(md-enhance): fix include option

### DIFF
--- a/docs/md-enhance/src/config.md
+++ b/docs/md-enhance/src/config.md
@@ -252,7 +252,7 @@ Please see [source code](https://github.com/vuepress-theme-hope/vuepress-theme-h
      *
      * @default (path) => path
      */
-    getPath?: (path: string) => string;
+    resolvePath?: (path: string, cwd: string | null) => string;
 
     /**
      * Whether deep include files in included Markdown files

--- a/docs/md-enhance/src/guide/include.md
+++ b/docs/md-enhance/src/guide/include.md
@@ -332,7 +332,7 @@ interface IncludeOptions {
    *
    * @default (path) => path
    */
-  getPath?: (path: string) => string;
+  resolvePath?: (path: string, cwd: string | null) => string;
 
   /**
    * Whether deep include files in included Markdown files

--- a/docs/md-enhance/src/zh/config.md
+++ b/docs/md-enhance/src/zh/config.md
@@ -232,7 +232,7 @@ interface TaskListOptions {
      *
      * @default (path) => path
      */
-    getPath?: (path: string) => string;
+    resolvePath?: (path: string, cwd: string | null) => string;
 
     /**
      * 是否深度导入包含的 Markdown 文件

--- a/docs/md-enhance/src/zh/guide/include.md
+++ b/docs/md-enhance/src/zh/guide/include.md
@@ -332,7 +332,7 @@ interface IncludeOptions {
    *
    * @default (path) => path
    */
-  getPath?: (path: string) => string;
+  resolvePath?: (path: string, cwd: string | null) => string;
 
   /**
    * 是否深度导入包含的 Markdown 文件

--- a/docs/theme/src/guide/markdown/include.md
+++ b/docs/theme/src/guide/markdown/include.md
@@ -340,7 +340,7 @@ interface IncludeOptions {
    *
    * @default (path) => path
    */
-  getPath?: (path: string) => string;
+  resolvePath?: (path: string, cwd: string | null) => string;
 
   /**
    * Whether deep include files in included Markdown files

--- a/docs/theme/src/ru/guide/markdown/include.md
+++ b/docs/theme/src/ru/guide/markdown/include.md
@@ -340,7 +340,7 @@ interface IncludeOptions {
    *
    * @default (path) => path
    */
-  getPath?: (path: string) => string;
+  resolvePath?: (path: string, cwd: string | null) => string;
 
   /**
    * Whether deep include files in included Markdown files

--- a/docs/theme/src/zh/guide/markdown/include.md
+++ b/docs/theme/src/zh/guide/markdown/include.md
@@ -339,7 +339,7 @@ interface IncludeOptions {
    *
    * @default (path) => path
    */
-  getPath?: (path: string) => string;
+  resolvePath?: (path: string, cwd: string | null) => string;
 
   /**
    * 是否深度导入包含的 Markdown 文件
@@ -370,7 +370,7 @@ export default defineUserConfig({
       mdEnhance: {
         // 添加 `@src` 别名支持
         include: {
-          getPath: (file) => {
+          resolvePath: (file) => {
             if (file.startsWith("@src"))
               return file.replace("@src", path.resolve(__dirname, ".."));
 


### PR DESCRIPTION
查看vuepress-them-hope主题源码，在ts描述文件中，对MarkdownItIncludeOptions的定义不支持getPath，而是resolvePath

参考文件源码：
-  https://github.com/vuepress-theme-hope/vuepress-theme-hope/blob/8a3f9756b87b0c4d2fa8d98c79f8ea90bd304273/packages/md-enhance/src/node/typings/index.ts  第1行
- https://github.com/mdit-plugins/mdit-plugins/blob/c10ecc5ead8f803a1d19004799380fad14e8496f/packages/include/src/options.ts  第22行