### PR TITLE
fix(theme): fix timeline date appearance

### DIFF
--- a/packages/theme/src/client/modules/blog/styles/timeline-items.scss
+++ b/packages/theme/src/client/modules/blog/styles/timeline-items.scss
@@ -156,7 +156,7 @@
     // inset-inline-end: calc(100% + 24px);
     right: calc(100% + 24px);
 
-    width: 40px;
+    width: 50px;
 
     font-size: 14px;
     line-height: 30px;


### PR DESCRIPTION
Width of timeline date (40px) is not wide enough when the content is relatively long and large (16px), so I adjust the width of timeline date container to 50px for some extra space.
时间线日期的宽度原本是 40px，如果日期比较长，在hover时又比较大（16px），宽度就不够了，把 timeline-date 的宽度调整到 50px 就能解决问题
