### PR TITLE
Fix typo in zh/guide/markdown/components.md

### DIFF
--- a/docs/theme/src/zh/guide/markdown/components.md
+++ b/docs/theme/src/zh/guide/markdown/components.md
@@ -218,8 +218,9 @@ export default {
 
 <BiliBili aid="34304064" cid="109293122" ratio="9:16" time="60" autoplay page="2" />
 
-````md
-<BiliBili aid="34304064" cid="109293122" ratio="9:16" time="60" autoplay page="2" />```
+```md
+<BiliBili aid="34304064" cid="109293122" ratio="9:16" time="60" autoplay page="2" />
+```
 
 有关可用属性，请参阅 <ProjectLink name="components" path="/zh/guide/bilibili.html">BiliBili</ProjectLink> 页面。
 


### PR DESCRIPTION
中文文档里一处code block多了个反引号，导致渲染出错