### PR TITLE
修复 样式相关 引入错误

### DIFF
--- a/docs/theme/src/guide/advanced/presets.md
+++ b/docs/theme/src/guide/advanced/presets.md
@@ -120,15 +120,15 @@ You can create a client config file `.vuepress/client.{ts,js}` and import the fo
 
 ### Docs
 
-- `"vuepress-theme-hope/presets/shinning-feature-panel.js"`: Add shinning effect to the features of the project home page.
+- `"vuepress-theme-hope/presets/shinning-feature-panel.scss"`: Add shinning effect to the features of the project home page.
 
 ### Blog
 
-- `"vuepress-theme-hope/presets/left-blog-info.js"`: Move the blogger information to the left of the article list.
+- `"vuepress-theme-hope/presets/left-blog-info.scss"`: Move the blogger information to the left of the article list.
 
 ### Others
 
-- `"vuepress-theme-hope/presets/bounce-icon.js"`: Add a mouseover bounce effect to the page icon.
+- `"vuepress-theme-hope/presets/bounce-icon.scss"`: Add a mouseover bounce effect to the page icon.
 
 ## More
 


### PR DESCRIPTION
为项目主页的特性添加闪光效果、将博主信息移动至文章列表的左侧、为页面图标添加鼠标悬停的跳动效果 应该 import scss