### PR TITLE
feat(comment2): support `lang` in Giscus

### DIFF
--- a/docs/comment2/src/config/giscus.md
+++ b/docs/comment2/src/config/giscus.md
@@ -113,3 +113,37 @@ Should be a built-in theme keyword or a css link starting with `https://`.
 Giscus theme used in darkmode
 
 Should be a built-in theme keyword or a css link starting with `https://`.
+
+## lang
+
+- Type: `GiscusLang`
+
+  ```ts
+  type GiscusLang =
+    | "ar"
+    | "de"
+    | "gsw"
+    | "en"
+    | "es"
+    | "fa"
+    | "fr"
+    | "id"
+    | "it"
+    | "ja"
+    | "ko"
+    | "nl"
+    | "pl"
+    | "pt"
+    | "ro"
+    | "ru"
+    | "th"
+    | "tr"
+    | "uk"
+    | "vi"
+    | "zh-CN"
+    | "zh-TW";
+  ```
+
+- Default: `usePageLang().value || "en"`
+
+The language which giscus will be displayed in

--- a/docs/comment2/src/zh/config/giscus.md
+++ b/docs/comment2/src/zh/config/giscus.md
@@ -113,3 +113,37 @@ Giscus 在日间模式下使用的主题
 Giscus 在夜间模式下使用的主题
 
 应为一个内置主题关键词或者一个 CSS 链接。
+
+## lang
+
+- 类型: `GiscusLang`
+
+  ```ts
+  type GiscusLang =
+    | "ar"
+    | "de"
+    | "gsw"
+    | "en"
+    | "es"
+    | "fa"
+    | "fr"
+    | "id"
+    | "it"
+    | "ja"
+    | "ko"
+    | "nl"
+    | "pl"
+    | "pt"
+    | "ro"
+    | "ru"
+    | "th"
+    | "tr"
+    | "uk"
+    | "vi"
+    | "zh-CN"
+    | "zh-TW";
+  ```
+
+- 默认值: `usePageLang().value || "en"`
+
+语言 giscus 将显示在

--- a/packages/comment2/src/client/components/Giscus.ts
+++ b/packages/comment2/src/client/components/Giscus.ts
@@ -10,38 +10,19 @@ import { LoadingIcon } from "vuepress-shared/client";
 import {
   type CommentPluginFrontmatter,
   type GiscusInputPosition,
+  type GiscusLang,
   type GiscusMapping,
   type GiscusOptions,
   type GiscusRepo,
   type GiscusTheme,
+  SUPPORTED_LANGUAGES,
 } from "../../shared/index.js";
 
 import "../styles/giscus.scss";
 
 declare const COMMENT_OPTIONS: GiscusOptions;
 
-const SUPPORTED_LANGUAGES = [
-  "de",
-  "gsw",
-  "en",
-  "es",
-  "fr",
-  "id",
-  "it",
-  "ja",
-  "ko",
-  "pl",
-  "ro",
-  "ru",
-  "tr",
-  "vi",
-  "zh-CN",
-  "zh-TW",
-] as const;
-
 type BooleanString = "0" | "1";
-
-export type GiscusLang = (typeof SUPPORTED_LANGUAGES)[number];
 
 export type GiscusLoading = "lazy" | "eager";
 
@@ -90,7 +71,7 @@ export default defineComponent({
     const loaded = ref(false);
 
     const giscusLang = computed(() => {
-      const lang = usePageLang().value as GiscusLang;
+      const lang = (giscusOptions.lang || usePageLang().value) as GiscusLang;
 
       if (SUPPORTED_LANGUAGES.includes(lang)) return lang;
 

--- a/packages/comment2/src/shared/options/giscus.ts
+++ b/packages/comment2/src/shared/options/giscus.ts
@@ -24,6 +24,33 @@ export type GiscusTheme =
   | "preferred_color_scheme"
   | `https://${string}`;
 
+export const SUPPORTED_LANGUAGES = [
+  "ar",
+  "de",
+  "gsw",
+  "en",
+  "es",
+  "fa",
+  "fr",
+  "id",
+  "it",
+  "ja",
+  "ko",
+  "nl",
+  "pl",
+  "pt",
+  "ro",
+  "ru",
+  "th",
+  "tr",
+  "uk",
+  "vi",
+  "zh-CN",
+  "zh-TW",
+] as const;
+
+export type GiscusLang = (typeof SUPPORTED_LANGUAGES)[number];
+
 export interface GiscusOptions extends BaseCommentOptions {
   provider: "Giscus";
 
@@ -125,4 +152,13 @@ export interface GiscusOptions extends BaseCommentOptions {
    * @default "dark"
    */
   darkTheme?: GiscusTheme;
+
+  /**
+   * The language which giscus will be displayed in
+   *
+   * 语言 giscus 将显示在
+   *
+   * @default usePageLang().value
+   */
+  lang?: GiscusLang;
 }


### PR DESCRIPTION
Were adding Giscus to my pt-BR [blog](https://github.com/GuiDevloper/guiwriter) but realized that options supported by Giscus (like `lang`) weren't implemented in [vuepress-plugin-comment2](https://github.com/vuepress-theme-hope/vuepress-theme-hope/tree/main/packages/comment2).

Then started experimenting how to make it work for me, ended realizing the lib is cleanly written and I could contribute this feature to others and here it is!

- Moved `SUPPORTED_LANGUAGES` constant from [components/Giscus.ts](https://github.com/GuiDevloper/vuepress-theme-hope/blob/a71689517b39ba03958e4f53094328cbe53b83e5/packages/comment2/src/client/components/Giscus.ts) to [shared/options/giscus.ts](https://github.com/GuiDevloper/vuepress-theme-hope/blob/a71689517b39ba03958e4f53094328cbe53b83e5/packages/comment2/src/shared/options/giscus.ts). Allowing that list to be written/updated only one time, also updated it with Giscus [locales list](https://github.com/giscus/giscus/tree/main/locales)!
- In docs described the default for `lang` as `usePageLang().value || "en"`. Best way I could think to illustrate that can be optional and dynamically changed by page

Tested it with the demo project and even did a [temporary fork](https://github.com/GuiDevloper/vuepress-plugin-comment2-fork) to use it at my blog right from the start! 🚀 

PS: I don't speak chinese, then used Translate to sync docs, sorry if mistaken!