### PR TITLE
修改中文翻译里与英文不符合的地方

### DIFF
--- a/docs/comment2/src/guide/README.md
+++ b/docs/comment2/src/guide/README.md
@@ -12,18 +12,17 @@ You can both set options with plugin options on Node side and set options in cli
 @tab With Plugin Options
 
 ```ts
-// .vuepress/config.ts
-module.exports = {
-  plugins: [
-    [
-      "@vuepress/comment2",
-      {
-        provider: "Artalk", // Artalk | Giscus | Waline | Twikoo
+import { commentPlugin } from "vuepress-plugin-comment2";
 
-        // other options here
-        // ...
-      },
-    ],
+// .vuepress/config.ts
+export default {
+  plugins: [
+    commentPlugin({
+      provider: "Artalk", // Artalk | Giscus | Waline | Twikoo
+
+      // other options here
+      // ...
+    }),
   ],
 };
 ```
@@ -79,6 +78,12 @@ By default, `<CommentService />` component is enabled globally, and you can use 
 - You can disable it locally by setting `comment: false` in page frontmatter.
 
 - To keep it globally disabled, please set `comment` to `false` in the plugin options. Then you can set `comment: true` in page frontmatter to enable it locally.
+
+## Comment ID
+
+You can set `commentID` option in page frontmatter to customize comment ID, which is used to identify comment storage item to use for a page.
+
+By default it will be the `path` of the page, which means if you are deploying the site to multiple places, page with same content across sites will share the same comment data.
 
 ## Comment Services
 

--- a/docs/comment2/src/zh/guide/README.md
+++ b/docs/comment2/src/zh/guide/README.md
@@ -12,18 +12,17 @@ icon: lightbulb
 @tab 通过插件选项
 
 ```ts
-// .vuepress/config.ts
-module.exports = {
-  plugins: [
-    [
-      "@vuepress/comment2",
-      {
-        provider: "Artalk", // Artalk | Giscus | Waline | Twikoo
+import { commentPlugin } from "vuepress-plugin-comment2";
 
-        // 在这里放置其他选项
-        // ...
-      },
-    ],
+// .vuepress/config.ts
+export default {
+  plugins: [
+    commentPlugin({
+      provider: "Artalk", // Artalk | Giscus | Waline | Twikoo
+
+      // 在这里放置其他选项
+      // ...
+    }),
   ],
 };
 ```
@@ -79,6 +78,12 @@ export default defineClientConfig({
 - 你可以通过在页面 frontmatter 中设置 `comment: false` 在本地禁用它。
 
 - 要使其全局禁用，请在插件选项中将 `comment` 设置为 `false`。 然后你可以在页面 frontmatter 中设置 comment: true 以在局部启用它。
+
+## 评论标识
+
+您可以在页面 frontmatter 中设置 commentID 选项来自定义评论 ID，该 ID 用于标识要用于页面的评论存储项。
+
+默认情况下，它将是页面的 `path` ，这意味着如果您将站点部署到多个位置，站点间具有相同内容的页面将共享相同的评论数据。
 
 ## 评论服务
 

--- a/docs/theme/src/zh/cookbook/tutorial/content.md
+++ b/docs/theme/src/zh/cookbook/tutorial/content.md
@@ -23,7 +23,7 @@ VuePress 是以 Markdown 为中心的。你项目中的每一个 Markdown 文件
 由于你的项目是通过创建助手生成的，那么你会得到以下文件结构:
 
 ```
-└─ docs
+└─ src
    ├─ guide
    │  ├─ ...
    │  └─ page.md

--- a/packages/comment2/src/client/components/Artalk.ts
+++ b/packages/comment2/src/client/components/Artalk.ts
@@ -22,6 +22,14 @@ export default defineComponent({
 
   props: {
     /**
+     * The path of the comment
+     */
+    identifier: {
+      type: String,
+      required: true,
+    },
+
+    /**
      * Whether the component is in darkmode
      *
      * 组件是否处于夜间模式
@@ -59,7 +67,7 @@ export default defineComponent({
             pageTitle: page.value.title,
             ...artalkOptions,
             el: artalkContainer.value!,
-            pageKey: page.value.path,
+            pageKey: props.identifier,
             darkMode: props.darkmode,
           });
 

--- a/packages/comment2/src/client/components/CommentService.ts
+++ b/packages/comment2/src/client/components/CommentService.ts
@@ -1,4 +1,4 @@
-import { usePageFrontmatter } from "@vuepress/client";
+import { usePageData, usePageFrontmatter } from "@vuepress/client";
 import { type VNode, computed, defineComponent, h } from "vue";
 import CommentProvider from "vuepress-plugin-comment2/provider";
 
@@ -19,6 +19,7 @@ export default defineComponent({
 
   setup(props) {
     const commentOptions = useCommentOptions();
+    const page = usePageData();
     const frontmatter = usePageFrontmatter<CommentPluginFrontmatter>();
 
     const enableComment = commentOptions.comment !== false;
@@ -32,6 +33,7 @@ export default defineComponent({
 
     return (): VNode | null =>
       h(CommentProvider, {
+        path: frontmatter.value.commentID || page.value.path,
         darkmode: props.darkmode,
         style: { display: enabled.value ? "block" : "none" },
       });

--- a/packages/comment2/src/client/components/Giscus.ts
+++ b/packages/comment2/src/client/components/Giscus.ts
@@ -1,4 +1,4 @@
-import { usePageData, usePageLang, withBase } from "@vuepress/client";
+import { usePageLang } from "@vuepress/client";
 import { type VNode, computed, defineComponent, h, onMounted, ref } from "vue";
 import { LoadingIcon } from "vuepress-shared/client";
 
@@ -66,6 +66,14 @@ export default defineComponent({
 
   props: {
     /**
+     * The path of the comment
+     */
+    identifier: {
+      type: String,
+      required: true,
+    },
+
+    /**
      * Whether the component is in darkmode
      *
      * 组件是否处于夜间模式
@@ -75,7 +83,6 @@ export default defineComponent({
 
   setup(props) {
     const giscusOptions = useGiscusOptions();
-    const page = usePageData();
 
     const enableGiscus = Boolean(
       giscusOptions.repo &&
@@ -112,7 +119,7 @@ export default defineComponent({
             ? giscusOptions.darkTheme || "dark"
             : giscusOptions.lightTheme || "light",
           mapping: giscusOptions.mapping || "pathname",
-          term: withBase(page.value.path),
+          term: props.identifier,
           inputPosition: giscusOptions.inputPosition || "top",
           reactionsEnabled:
             giscusOptions.reactionsEnabled === false ? "0" : "1",

--- a/packages/comment2/src/client/components/Twikoo.ts
+++ b/packages/comment2/src/client/components/Twikoo.ts
@@ -17,7 +17,17 @@ import "../styles/twikoo.scss";
 export default defineComponent({
   name: "TwikooComment",
 
-  setup() {
+  props: {
+    /**
+     * The path of the comment
+     */
+    identifier: {
+      type: String,
+      required: true,
+    },
+  },
+
+  setup(props) {
     const twikooOptions = useTwikooOptions();
     const lang = usePageLang();
     const page = usePageData();
@@ -40,6 +50,7 @@ export default defineComponent({
 
       await init({
         lang: lang.value === "zh-CN" ? "zh-CN" : "en",
+        path: props.identifier,
         ...twikooOptions,
         el: "#twikoo-comment",
       });

--- a/packages/comment2/src/client/components/Waline.ts
+++ b/packages/comment2/src/client/components/Waline.ts
@@ -1,9 +1,4 @@
-import {
-  usePageData,
-  usePageFrontmatter,
-  usePageLang,
-  withBase,
-} from "@vuepress/client";
+import { usePageFrontmatter, usePageLang } from "@vuepress/client";
 import { pageviewCount } from "@waline/client/dist/pageview.mjs";
 import {
   type VNode,
@@ -41,9 +36,18 @@ export { pageviewCount };
 export default defineComponent({
   name: "WalineComment",
 
-  setup() {
+  props: {
+    /**
+     * The path of the comment
+     */
+    identifier: {
+      type: String,
+      required: true,
+    },
+  },
+
+  setup(props) {
     const walineOptions = useWalineOptions();
-    const page = usePageData();
     const frontmatter = usePageFrontmatter<CommentPluginFrontmatter>();
     const lang = usePageLang();
     const walineLocale = useLocaleConfig(walineLocales);
@@ -64,19 +68,17 @@ export default defineComponent({
       );
     });
 
-    const walineKey = computed(() => withBase(page.value.path));
-
     const walineProps = computed(() => ({
       lang: lang.value === "zh-CN" ? "zh-CN" : "en",
       locale: walineLocale.value,
       dark: "html.dark",
       ...walineOptions,
-      path: walineKey.value,
+      path: props.identifier,
     }));
 
     onMounted(() => {
       watch(
-        walineKey,
+        () => props.identifier,
         () => {
           abort?.();
 
@@ -85,7 +87,7 @@ export default defineComponent({
               setTimeout(() => {
                 abort = pageviewCount({
                   serverURL: walineOptions.serverURL,
-                  path: walineKey.value,
+                  path: props.identifier,
                 });
               }, walineOptions.delay || 800);
             });

--- a/packages/comment2/src/shared/frontmatter.ts
+++ b/packages/comment2/src/shared/frontmatter.ts
@@ -11,6 +11,13 @@ export interface CommentPluginFrontmatter extends BasePageFrontMatter {
   comment?: boolean;
 
   /**
+   * Comment identifier
+   *
+   * 评论标识符
+   */
+  commentID?: string;
+
+  /**
    * @description Only available when using valine
    *
    * 是否启用访问量


### PR DESCRIPTION
英文的结构是
└─ src
   ├─ guide
   │  ├─ ...
   │  └─ page.md
   │  └─ markdown.md
   │  └─ README.md
   ├─ ...
   ├─ slide.md
   └─ README.md

但是中文在这部分没有改正，容易造成误解