### PR TITLE
fix(md-enhance): card slots issue

### DIFF
--- a/packages/md-enhance/src/client/components/VPCard.ts
+++ b/packages/md-enhance/src/client/components/VPCard.ts
@@ -66,7 +66,7 @@ const VPCard: FunctionalComponent<CardProps> = ({
 
   return isLinkExternal(link)
     ? h("a", { href: link, target: "_blank", ...props }, children)
-    : h(VPLink, { to: link, ...props }, children);
+    : h(VPLink, { to: link, ...props }, () => children);
 };
 
 VPCard.displayName = "VPCard";


### PR DESCRIPTION
解决 Markdown 增强中的卡片 Card 的 link 属性使用本地路径时控制台产生的警告

示例：

```card
title: Mr.Hope
desc: Where there is light, there is hope
logo: https://mrhope.site/logo.svg
link: /test
color: rgba(253, 230, 138, 0.15)
```

控制台警告：

<img width="923" alt="image" src="https://github.com/vuepress-theme-hope/vuepress-theme-hope/assets/40930677/ed512b63-7ff4-4ff0-ace8-2bb614ca03ae">

`yarn build` 时也会警告：

<img width="892" alt="image" src="https://github.com/vuepress-theme-hope/vuepress-theme-hope/assets/40930677/6fe5f27e-b70d-4f30-8bc9-06eeaf3a134a">

解决方案：将默认插槽更改为函数插槽
