### PR TITLE
修复在设置了 base URL 后 pageview 在文章主体页面下会失效的问题

### DIFF
--- a/packages/theme/src/client/modules/info/components/PageViewInfo.ts
+++ b/packages/theme/src/client/modules/info/components/PageViewInfo.ts
@@ -1,4 +1,3 @@
-import { withBase } from "@vuepress/client";
 import { isString } from "@vuepress/shared";
 import { useMutationObserver } from "@vueuse/core";
 import type { VNode } from "vue";
@@ -71,7 +70,7 @@ export default defineComponent({
                   /** visitorID */
                   "data-path": isString(props.pageview)
                     ? props.pageview
-                    : withBase(route.path),
+                    : route.path,
                 },
                 "...",
               ),


### PR DESCRIPTION
当在 `config.ts` 中设置了 `base` 不为 `/` 后会导致  `CommentService` 组件的 `identifier` 属性和 `.waline-pageview-count` 元素的 `data-path` 不匹配 （`data-path` 带有 `base URL` 而 `identifier` 没有），此时就会触发 `pageviewCount` 执行过程中认为需要获取其他 `page` 的值并在 `updatePageview ` 后再次调用  `getPageview ` （实际是同一个）。 而调用 `updatePageview `  和  `getPageview`  时又分别传入了上述两个不同的参数，导致 `update` 的路径和  `get` 的路径不同，从而无法正常显示阅读量。


本次 PR 解决了上述问题。 