### PR TITLE
feat(md-enhance): add unocss preset to playground

### DIFF
--- a/docs/md-enhance/src/.vuepress/theme.ts
+++ b/docs/md-enhance/src/.vuepress/theme.ts
@@ -49,7 +49,7 @@ export default theme("md-enhance", {
       mark: true,
       mermaid: true,
       playground: {
-        presets: ["ts", "vue"],
+        presets: ["ts", "vue", "unocss"],
       },
       presentation: ["highlight", "math", "search", "notes", "zoom"],
       stylize: [

--- a/docs/md-enhance/src/config.md
+++ b/docs/md-enhance/src/config.md
@@ -475,6 +475,17 @@ Stylize inline tokens to create snippet you want.
     service?: string;
   }
 
+  interface UnoPresetPlaygroundOptions {
+    /**
+     * external playground service url
+     *
+     * 交互演示外部地址
+     *
+     * @default "https://unocss.dev/play"
+     */
+    service?: string;
+  }
+
   interface VuePresetPlaygroundOptions {
     /**
      * external playground service url

--- a/docs/md-enhance/src/guide/playground.md
+++ b/docs/md-enhance/src/guide/playground.md
@@ -13,7 +13,7 @@ The plugin provides you playground support.
 
 @tab TS
 
-```ts {8-33}
+```ts {8-36}
 // .vuepress/config.ts
 import { mdEnhance } from "vuepress-plugin-md-enhance";
 
@@ -26,6 +26,7 @@ export default {
         presets: [
           "ts",
           "vue",
+          "unocss",
           {
             name: "playground#language",
             component: "PlaygroundComponent",
@@ -44,6 +45,9 @@ export default {
           vue: {
             // ...
           },
+          unocss: {
+            // ...
+          },
         },
       },
     }),
@@ -53,7 +57,7 @@ export default {
 
 @tab JS
 
-```js {8-33}
+```js {8-36}
 // .vuepress/config.js
 import { mdEnhance } from "vuepress-plugin-md-enhance";
 
@@ -66,6 +70,7 @@ export default {
         presets: [
           "ts",
           "vue",
+          "unocss",
           {
             name: "playground#language",
             component: "PlaygroundComponent",
@@ -82,6 +87,9 @@ export default {
             // ...
           },
           vue: {
+            // ...
+          },
+          unocss: {
             // ...
           },
         },
@@ -109,7 +117,7 @@ You can see the below demos to see more details.
 
 ## Available presets
 
-Currently, we support `ts` and `vue` presets, and we are looking forward to more presets coming from PRs.
+Currently, we support `ts`, `vue` and `unocss` presets, and we are looking forward to more presets coming from PRs.
 
 If you want to add a playground of your own, you can add a preset by you own in [Advanced Section](#advanced), and welcome to open a PR about your fantastic preset.
 
@@ -130,6 +138,18 @@ Vue preset is using the official playground by default, and do not support custo
 But if you only want a few demos instead of bundling a whole vue playground, you can use this preset to create a `<iframe>`.
 
 Only `service`, `dev` and `ssr` option is available in `@setting` directive.
+
+:::
+
+::: info UnoCSS Preset
+
+UnoCSS preset is using official playground by default. You can use `@file` to input different content, every file type only support one. You can set three file types as follows:
+
+- `xxx.html` match `HTML` content. If no html file, The official default value will be used.
+- `xxx.js` match `Config` content. If no config file, The official default value will be used.
+- `xxx.css` match `Custom CSS` content.
+
+If you need, you can set your own service url through `playground.config.unocss.service` in config file.
 
 :::
 
@@ -363,6 +383,76 @@ const msg = ref("Hello Playground!");
 {
   "dev": true,
   "ssr": true
+}
+```
+
+:::
+````
+
+::::
+
+### UnoCSS
+
+::: playground#unocss UnoCSS demo
+
+@file index.html
+
+```html
+<div class="flex flex-col text-center h-full justify-center">
+  <div class="text-red">TEST for default preset</div>
+  <div class="text-$fd-color">TEST for custom css</div>
+</div>
+```
+
+@file config.js
+
+```js
+import { defineConfig, presetUno } from "unocss";
+
+export default defineConfig({
+  presets: [presetUno()],
+});
+```
+
+@file custom.css
+
+```css
+:root {
+  --fd-color: green;
+}
+```
+
+:::
+
+:::: details Code
+
+````md
+::: playground#unocss UnoCSS demo
+
+@file index.html
+
+```html
+<div class="flex flex-col text-center h-full justify-center">
+  <div class="text-red">TEST for default preset</div>
+  <div class="text-$fd-color">TEST for custom css</div>
+</div>
+```
+
+@file config.js
+
+```js
+import { defineConfig, presetUno } from "unocss";
+
+export default defineConfig({
+  presets: [presetUno()],
+});
+```
+
+@file custom.css
+
+```css
+:root {
+  --fd-color: green;
 }
 ```
 

--- a/docs/md-enhance/src/zh/config.md
+++ b/docs/md-enhance/src/zh/config.md
@@ -479,6 +479,17 @@ interface TaskListOptions {
     service?: string;
   }
 
+  interface UnoPresetPlaygroundOptions {
+    /**
+     * external playground service url
+     *
+     * 交互演示外部地址
+     *
+     * @default "https://unocss.dev/play"
+     */
+    service?: string;
+  }
+
   interface VuePresetPlaygroundOptions {
     /**
      * 交互演示外部地址

--- a/docs/md-enhance/src/zh/guide/playground.md
+++ b/docs/md-enhance/src/zh/guide/playground.md
@@ -13,7 +13,7 @@ icon: code
 
 @tab TS
 
-```ts {8-33}
+```ts {8-36}
 // .vuepress/config.ts
 import { mdEnhance } from "vuepress-plugin-md-enhance";
 
@@ -26,6 +26,7 @@ export default {
         presets: [
           "ts",
           "vue",
+          "unocss",
           {
             name: "playground#language",
             component: "PlaygroundComponent",
@@ -44,6 +45,9 @@ export default {
           vue: {
             // ...
           },
+          unocss: {
+            // ...
+          },
         },
       },
     }),
@@ -53,7 +57,7 @@ export default {
 
 @tab JS
 
-```js {8-33}
+```js {8-36}
 // .vuepress/config.js
 import { mdEnhance } from "vuepress-plugin-md-enhance";
 
@@ -66,6 +70,7 @@ export default {
         presets: [
           "ts",
           "vue",
+          "unocss",
           {
             name: "playground#language",
             component: "PlaygroundComponent",
@@ -82,6 +87,9 @@ export default {
             // ...
           },
           vue: {
+            // ...
+          },
+          unocss: {
             // ...
           },
         },
@@ -109,7 +117,7 @@ export default {
 
 ## 可用预设
 
-目前，我们支持 `ts` 和 `vue` 预设，我们期待更多来自 PR 的预设。
+目前，我们支持 `ts`、`vue`和 `unocss` 预设，我们期待更多来自 PR 的预设。
 
 如果你想添加自己的交互演示，可以在 [高级用法](#高级用法) 中添加你自己的预设。同时我们欢迎为你的精彩预设创建 PR。
 
@@ -131,6 +139,17 @@ Vue 预设默认使用官方 playground，并不像 [Vue Playground](./vue-playg
 
 `@setting` 指令中只有 `service`、`dev` 和 `ssr` 选项可用。
 
+:::
+
+::: info UnoCSS 预设
+
+UnoCSS 预设默认使用官方 playground，通过 `@file` 的不同文件类型，对应官方 playground 的相应输入，每个文件类型仅支持一个文件，具体：
+
+- `xxx.html` 对应 `HTML`，没有对应文件则使用官方的默认值
+- `xxx.js` 对应 `Config`，没有对应文件则会使用官方默认值
+- `xxx.css` 对应 `Custom CSS`
+
+在配置中，可以通过 `playground.config.unocss` 中的 `service` 选项使用官方交互演示之外的其他服务，以防你想部署自己的交互演示站点
 :::
 
 ## 案例
@@ -363,6 +382,76 @@ const msg = ref("Hello Playground!");
 {
   "dev": true,
   "ssr": true
+}
+```
+
+:::
+````
+
+::::
+
+### UnoCSS
+
+::: playground#unocss UnoCSS 案例
+
+@file index.html
+
+```html
+<div class="flex flex-col text-center h-full justify-center">
+  <div class="text-red">TEST for default preset</div>
+  <div class="text-$fd-color">TEST for custom css</div>
+</div>
+```
+
+@file config.js
+
+```js
+import { defineConfig, presetUno } from "unocss";
+
+export default defineConfig({
+  presets: [presetUno()],
+});
+```
+
+@file custom.css
+
+```css
+:root {
+  --fd-color: green;
+}
+```
+
+:::
+
+:::: details 代码
+
+````md
+::: playground#unocss UnoCSS 案例
+
+@file index.html
+
+```html
+<div class="flex flex-col text-center h-full justify-center">
+  <div class="text-red">TEST for default preset</div>
+  <div class="text-$fd-color">TEST for custom css</div>
+</div>
+```
+
+@file config.js
+
+```js
+import { defineConfig, presetUno } from "unocss";
+
+export default defineConfig({
+  presets: [presetUno()],
+});
+```
+
+@file custom.css
+
+```css
+:root {
+  --fd-color: green;
 }
 ```
 

--- a/docs/theme/src/.vuepress/theme.ts
+++ b/docs/theme/src/.vuepress/theme.ts
@@ -140,7 +140,7 @@ export default theme("theme", {
       mark: true,
       mermaid: true,
       playground: {
-        presets: ["ts", "vue"],
+        presets: ["ts", "vue", "unocss"],
       },
       presentation: ["highlight", "math", "search", "notes", "zoom"],
       stylize: [

--- a/docs/theme/src/config/plugins/md-enhance.md
+++ b/docs/theme/src/config/plugins/md-enhance.md
@@ -467,6 +467,17 @@ Stylize inline tokens to create snippet you want.
     service?: string;
   }
 
+  interface UnoPresetPlaygroundOptions {
+    /**
+     * external playground service url
+     *
+     * 交互演示外部地址
+     *
+     * @default "https://unocss.dev/play"
+     */
+    service?: string;
+  }
+
   interface VuePresetPlaygroundOptions {
     /**
      * external playground service url

--- a/docs/theme/src/guide/markdown/playground.md
+++ b/docs/theme/src/guide/markdown/playground.md
@@ -18,7 +18,7 @@ Let the Markdown file support playground in your VuePress site.
 
 @tab TS
 
-```ts {8-33}
+```ts {8-36}
 // .vuepress/config.ts
 import { defineUserConfig } from "vuepress";
 import { hopeTheme } from "vuepress-theme-hope";
@@ -33,6 +33,7 @@ export default defineUserConfig({
           presets: [
             "ts",
             "vue",
+            "unocss",
             {
               name: "playground#language",
               component: "PlaygroundComponent",
@@ -51,6 +52,9 @@ export default defineUserConfig({
             vue: {
               // ...
             },
+            unocss: {
+              // ...
+            },
           },
         },
       },
@@ -61,7 +65,7 @@ export default defineUserConfig({
 
 @tab JS
 
-```js {8-33}
+```js {8-36}
 // .vuepress/config.js
 import { hopeTheme } from "vuepress-theme-hope";
 
@@ -75,6 +79,7 @@ export default {
           presets: [
             "ts",
             "vue",
+            "unocss",
             {
               name: "playground#language",
               component: "PlaygroundComponent",
@@ -91,6 +96,9 @@ export default {
               // ...
             },
             vue: {
+              // ...
+            },
+            unocss: {
               // ...
             },
           },
@@ -119,7 +127,7 @@ You can see the below demos to see more details.
 
 ## Available presets
 
-Currently, we support `ts` and `vue` presets, and we are looking forward to more presets coming from PRs.
+Currently, we support `ts`, `vue` and `unocss` presets, and we are looking forward to more presets coming from PRs.
 
 If you want to add a playground of your own, you can add a preset by you own in [Advanced Section](#advanced), and welcome to open a PR about your fantastic preset.
 
@@ -140,6 +148,18 @@ Vue preset is using the official playground by default, and do not support custo
 But if you only want a few demos instead of bundling a whole vue playground, you can use this preset to create a `<iframe>`.
 
 Only `service`, `dev` and `ssr` option is available in `@setting` directive.
+
+:::
+
+::: info UnoCSS Preset
+
+UnoCSS preset is using official playground by default. You can use `@file` to input different content, every file type only support one. You can set three file types as follows:
+
+- `xxx.html` match `HTML` content. If no html file, The official default value will be used.
+- `xxx.js` match `Config` content. If no config file, The official default value will be used.
+- `xxx.css` match `Custom CSS` content.
+
+If you need, you can set your own service url through `playground.config.unocss.service` in config file.
 
 :::
 
@@ -373,6 +393,76 @@ const msg = ref("Hello Playground!");
 {
   "dev": true,
   "ssr": true
+}
+```
+
+:::
+````
+
+::::
+
+### UnoCSS
+
+::: playground#unocss UnoCSS demo
+
+@file index.html
+
+```html
+<div class="flex flex-col text-center h-full justify-center">
+  <div class="text-red">TEST for default preset</div>
+  <div class="text-$fd-color">TEST for custom css</div>
+</div>
+```
+
+@file config.js
+
+```js
+import { defineConfig, presetUno } from "unocss";
+
+export default defineConfig({
+  presets: [presetUno()],
+});
+```
+
+@file custom.css
+
+```css
+:root {
+  --fd-color: green;
+}
+```
+
+:::
+
+:::: details Code
+
+````md
+::: playground#unocss UnoCSS demo
+
+@file index.html
+
+```html
+<div class="flex flex-col text-center h-full justify-center">
+  <div class="text-red">TEST for default preset</div>
+  <div class="text-$fd-color">TEST for custom css</div>
+</div>
+```
+
+@file config.js
+
+```js
+import { defineConfig, presetUno } from "unocss";
+
+export default defineConfig({
+  presets: [presetUno()],
+});
+```
+
+@file custom.css
+
+```css
+:root {
+  --fd-color: green;
 }
 ```
 

--- a/docs/theme/src/zh/config/plugins/md-enhance.md
+++ b/docs/theme/src/zh/config/plugins/md-enhance.md
@@ -471,6 +471,17 @@ interface TaskListOptions {
     service?: string;
   }
 
+  interface UnoPresetPlaygroundOptions {
+    /**
+     * external playground service url
+     *
+     * 交互演示外部地址
+     *
+     * @default "https://unocss.dev/play"
+     */
+    service?: string;
+  }
+
   interface VuePresetPlaygroundOptions {
     /**
      * 交互演示外部地址

--- a/docs/theme/src/zh/guide/markdown/playground.md
+++ b/docs/theme/src/zh/guide/markdown/playground.md
@@ -18,7 +18,7 @@ tag:
 
 @tab TS
 
-```ts {8-33}
+```ts {8-37}
 // .vuepress/config.ts
 import { defineUserConfig } from "vuepress";
 import { hopeTheme } from "vuepress-theme-hope";
@@ -32,6 +32,7 @@ export default defineUserConfig({
         presets: [
           "ts",
           "vue",
+          "unocss",
           {
             name: "playground#language",
             component: "PlaygroundComponent",
@@ -50,6 +51,9 @@ export default defineUserConfig({
           vue: {
             // ...
           },
+          unocss: {
+            // ...
+          },
         },
       },
     },
@@ -59,7 +63,7 @@ export default defineUserConfig({
 
 @tab JS
 
-```js {8-33}
+```js {8-37}
 // .vuepress/config.js
 import { hopeTheme } from "vuepress-theme-hope";
 
@@ -72,6 +76,7 @@ export default {
         presets: [
           "ts",
           "vue",
+          "unocss",
           {
             name: "playground#language",
             component: "PlaygroundComponent",
@@ -88,6 +93,9 @@ export default {
             // ...
           },
           vue: {
+            // ...
+          },
+          unocss: {
             // ...
           },
         },
@@ -115,7 +123,7 @@ export default {
 
 ## 可用预设
 
-目前，我们支持 `ts` 和 `vue` 预设，我们期待更多来自 PR 的预设。
+目前，我们支持 `ts`、`vue`和 `unocss` 预设，我们期待更多来自 PR 的预设。
 
 如果你想添加自己的交互演示，可以在 [高级用法](#高级用法) 中添加你自己的预设。同时我们欢迎为你的精彩预设创建 PR。
 
@@ -137,6 +145,17 @@ Vue 预设默认使用官方交互演示，并不像 [Vue 交互演示](./vue-pl
 
 `@setting` 指令中只有 `service`、`dev` 和 `ssr` 选项可用。
 
+:::
+
+::: info UnoCSS 预设
+
+UnoCSS 预设默认使用官方 playground，通过 `@file` 的不同文件类型，对应官方 playground 的相应输入，每个文件类型仅支持一个文件，具体：
+
+- `xxx.html` 对应 `HTML`，没有对应文件则使用官方的默认值
+- `xxx.js` 对应 `Config`，没有对应文件则会使用官方默认值
+- `xxx.css` 对应 `Custom CSS`
+
+在配置中，可以通过 `playground.config.unocss` 中的 `service` 选项使用官方交互演示之外的其他服务，以防你想部署自己的交互演示站点
 :::
 
 ## 案例
@@ -369,6 +388,76 @@ const msg = ref("Hello Playground!");
 {
   "dev": true,
   "ssr": true
+}
+```
+
+:::
+````
+
+::::
+
+### UnoCSS
+
+::: playground#unocss UnoCSS 案例
+
+@file index.html
+
+```html
+<div class="flex flex-col text-center h-full justify-center">
+  <div class="text-red">TEST for default preset</div>
+  <div class="text-$fd-color">TEST for custom css</div>
+</div>
+```
+
+@file config.js
+
+```js
+import { defineConfig, presetUno } from "unocss";
+
+export default defineConfig({
+  presets: [presetUno()],
+});
+```
+
+@file custom.css
+
+```css
+:root {
+  --fd-color: green;
+}
+```
+
+:::
+
+:::: details 代码
+
+````md
+::: playground#unocss UnoCSS 案例
+
+@file index.html
+
+```html
+<div class="flex flex-col text-center h-full justify-center">
+  <div class="text-red">TEST for default preset</div>
+  <div class="text-$fd-color">TEST for custom css</div>
+</div>
+```
+
+@file config.js
+
+```js
+import { defineConfig, presetUno } from "unocss";
+
+export default defineConfig({
+  presets: [presetUno()],
+});
+```
+
+@file custom.css
+
+```css
+:root {
+  --fd-color: green;
 }
 ```
 

--- a/packages/md-enhance/__tests__/unit/__snapshots__/playground.spec.ts.snap
+++ b/packages/md-enhance/__tests__/unit/__snapshots__/playground.spec.ts.snap
@@ -122,6 +122,18 @@ exports[`playground > ts preset > Should work 2`] = `
 "
 `;
 
+exports[`playground > unocss preset > Should work 1`] = `
+"<Playground key=\\"78949b8e\\" title=\\"UnoCSS%20demo%201\\" link=\\"https%3A%2F%2Funocss.dev%2Fplay%2F%3Fhtml%3DDwEwlgbgBAxgNgQwM5ILwCIAuBTAHpgWgCdsR0A%2BAVQDsB7AYQGVGoAVAUUdeAHpwJyAKCA\\">
+</Playground>
+"
+`;
+
+exports[`playground > unocss preset > Should work 2`] = `
+"<Playground key=\\"78949b8c\\" title=\\"UnoCSS%20demo%202\\" link=\\"https%3A%2F%2Funocss.dev%2Fplay%2F%3Fhtml%3DDwEwlgbgBAxgNgQwM5ILwCIAuBTAHpgWgBIAzEAmAezkoCd0A%2BAVQDtKBhAZU6gBUBRTrygAmYAHpwEBgCggA%26config%3DJYWwDg9gTgLgBAbwFBzgEwKYDNgDsMDCEuOA5gDQpxhQYDOGMAqrhJQL5xZQQhwDkAV1YBjOnX5IkGAB6RY6bAENBAG3iYc%2BIiWCkAFMlQ16jOgC44AbSrHaDZq30BKSqgC6Sds6lA%26css%3DFwJw9mAuAEDeBQ1oFpkDMAmyDGYA2YIw0IAphgNzwC%2B88QA\\">
+</Playground>
+"
+`;
+
 exports[`playground > vue preset > Should work 1`] = `
 "<Playground key=\\"68440394\\" title=\\"Vue%20demo%20with%20customized%20imports\\" link=\\"https%3A%2F%2Fsfc.vuejs.org%2F%23eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gXCJ2dWVcIjtcblxuaW1wb3J0IENvbXAgZnJvbSBcIi4vQ29tcC52dWVcIjtcblxuY29uc3QgbXNnID0gcmVmKFwiSGVsbG8gV29ybGQhXCIpO1xuPC9zY3JpcHQ%2BXG5cbjx0ZW1wbGF0ZT5cbiAgPGgxPnt7IG1zZyB9fTwvaDE%2BXG4gIDxpbnB1dCB2LW1vZGVsPVwibXNnXCIgLz5cbiAgPENvbXAgLz5cbjwvdGVtcGxhdGU%2BXG4iLCJDb21wLnZ1ZSI6Ijx0ZW1wbGF0ZT5cbiAgPGRpdj5Db21wPC9kaXY%2BXG48L3RlbXBsYXRlPlxuIiwiaW1wb3J0LW1hcC5qc29uIjoie1xuICBcImltcG9ydHNcIjoge1xuICAgIFwidnVlXCI6IFwiaHR0cHM6Ly9zZmMudnVlanMub3JnL3Z1ZS5ydW50aW1lLmVzbS1icm93c2VyLmpzXCJcbiAgfVxufSJ9\\">
 </Playground>

--- a/packages/md-enhance/__tests__/unit/playground.spec.ts
+++ b/packages/md-enhance/__tests__/unit/playground.spec.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getTSPlaygroundPreset,
+  getUnoPlaygroundPreset,
   getVuePlaygroundPreset,
   playground,
 } from "../../src/node/markdown-it/playground/index.js";
@@ -453,6 +454,67 @@ const msg = ref("Hello Playground!");
 }\
 `,
       });
+    });
+  });
+
+  describe("unocss preset", () => {
+    const markdownItWithUnoPreset = MarkdownIt({ linkify: true }).use(
+      playground,
+      getUnoPlaygroundPreset({}),
+    );
+
+    it("Should work", () => {
+      const result1 = markdownItWithUnoPreset.render(`
+::: playground#unocss UnoCSS demo 1
+
+@file index.html
+
+\`\`\`html
+<div class="text-red">UnoCSS TEST</div>
+\`\`\`
+
+:::
+`);
+
+      const result2 = markdownItWithUnoPreset.render(`
+::: playground#unocss UnoCSS demo 2
+
+@file index.html
+
+\`\`\`html
+<div class="text-$fd-color">UnoCSS TEST 2</div>
+\`\`\`
+
+@file config.js
+
+\`\`\`js
+import {
+  defineConfig,
+  presetUno,
+} from 'unocss'
+
+export default defineConfig({
+  presets: [
+    presetUno(),
+  ]
+})
+
+\`\`\`
+
+@file custom.css
+
+\`\`\`css
+:root {
+  --fd-color: red;
+}
+
+\`\`\`
+
+:::
+`);
+
+      expect(result1).toMatchSnapshot();
+      expect(result2).toMatchSnapshot();
     });
   });
 });

--- a/packages/md-enhance/src/node/markdown-it/playground/index.ts
+++ b/packages/md-enhance/src/node/markdown-it/playground/index.ts
@@ -1,3 +1,4 @@
 export * from "./plugin.js";
 export * from "./ts.js";
 export * from "./vue.js";
+export * from "./uno.js";

--- a/packages/md-enhance/src/node/markdown-it/playground/uno.ts
+++ b/packages/md-enhance/src/node/markdown-it/playground/uno.ts
@@ -1,0 +1,66 @@
+import { endsWith, keys } from "vuepress-shared/node";
+
+import { compressToEncodedURIComponent as encode } from "./ventors/lzstring.js";
+import type {
+  PlaygroundData,
+  PlaygroundOptions,
+  UnoPresetPlaygroundOptions,
+} from "../../typings/index.js";
+import { logger } from "../../utils.js";
+
+/** Gets a query string representation (hash + queries) */
+export const generateUnoURL = (
+  service: string,
+  inputHTML: string,
+  customCSS: string,
+  customConfigRaw: string,
+): string => {
+  const getParam = (key: string, value: string, sign: string = "&"): string => {
+    if (value) return `${sign}${key}=${encode(value)}`;
+
+    return "";
+  };
+  const params = `/${getParam("html", inputHTML, "?")}${getParam(
+    "config",
+    customConfigRaw,
+  )}${getParam("css", customCSS)}`;
+
+  return `${service}${params}`;
+};
+
+export const getUnoPlaygroundPreset = ({
+  service = "https://unocss.dev/play",
+}: UnoPresetPlaygroundOptions = {}): PlaygroundOptions => ({
+  name: "playground#unocss",
+  propsGetter: ({
+    title = "",
+    files,
+    key,
+  }: PlaygroundData): Record<string, string> => {
+    const htmlFiles = keys(files).filter((key) => endsWith(key, ".html"));
+    const cssFiles = keys(files).filter((key) => endsWith(key, ".css"));
+    const configFiles = keys(files).filter(
+      (key) => endsWith(key, ".js") || endsWith(key, ".ts"),
+    );
+
+    if (htmlFiles.length > 1 || cssFiles.length > 1 || configFiles.length > 1)
+      logger.error("UnoCSS playground only support 1 html/css/config file");
+
+    const simplifyParam = (inputFiles: string[]): string => {
+      return inputFiles.length === 1 ? files[inputFiles[0]].content : "";
+    };
+
+    const link = generateUnoURL(
+      service,
+      simplifyParam(htmlFiles),
+      simplifyParam(cssFiles),
+      simplifyParam(configFiles),
+    );
+
+    return {
+      key,
+      title,
+      link: encodeURIComponent(link),
+    };
+  },
+});

--- a/packages/md-enhance/src/node/options.ts
+++ b/packages/md-enhance/src/node/options.ts
@@ -14,6 +14,7 @@ import type {
   StylizeOptions,
   TSPresetPlaygroundOptions,
   TasklistOptions,
+  UnoPresetPlaygroundOptions,
   VuePresetPlaygroundOptions,
 } from "./typings/index.js";
 import type { CodeDemoOptions } from "../shared/index.js";
@@ -365,11 +366,12 @@ export interface MarkdownEnhanceOptions {
    */
   playground?: {
     /** Playground presets */
-    presets: ("ts" | "vue" | PlaygroundOptions)[];
+    presets: ("ts" | "vue" | "unocss" | PlaygroundOptions)[];
     /** Playground config */
     config?: {
       ts?: TSPresetPlaygroundOptions;
       vue?: VuePresetPlaygroundOptions;
+      unocss?: UnoPresetPlaygroundOptions;
     };
   };
 

--- a/packages/md-enhance/src/node/plugin.ts
+++ b/packages/md-enhance/src/node/plugin.ts
@@ -50,6 +50,7 @@ import {
   echarts,
   flowchart,
   getTSPlaygroundPreset,
+  getUnoPlaygroundPreset,
   getVuePlaygroundPreset,
   hint,
   mermaid,
@@ -351,6 +352,8 @@ export const mdEnhancePlugin =
               md.use(playground, getTSPlaygroundPreset(config.ts || {}));
             else if (preset === "vue")
               md.use(playground, getVuePlaygroundPreset(config.vue || {}));
+            else if (preset === "unocss")
+              md.use(playground, getUnoPlaygroundPreset(config.unocss || {}));
             else if (isPlainObject(preset)) md.use(playground, preset);
           });
         }

--- a/packages/md-enhance/src/node/typings/playground.ts
+++ b/packages/md-enhance/src/node/typings/playground.ts
@@ -140,3 +140,14 @@ export interface VuePresetPlaygroundOptions {
    */
   ssr?: boolean;
 }
+
+export interface UnoPresetPlaygroundOptions {
+  /**
+   * external playground service url
+   *
+   * 交互演示外部地址
+   *
+   * @default "https://unocss.dev/play"
+   */
+  service?: string;
+}


### PR DESCRIPTION
Add a unocss playground preset. This pr's main change:
- add a unocss preset in packages/md-enhance
- modify playground docs in docs/md-enhance (both en & zh)
- modify playground cos in docs/theme (both en & zh)