### PR TITLE
docs(theme): clarify include syntax of C#, add include syntax of C/C++

### DIFF
--- a/docs/theme/src/guide/markdown/include.md
+++ b/docs/theme/src/guide/markdown/include.md
@@ -303,6 +303,8 @@ CD /D "%~dp0"
 @tab C#
 
 ```cs
+// This is actually C# code, the tab name is not displayed correctly
+
 using System;
 
 namespace HelloWorldApp {
@@ -322,6 +324,33 @@ namespace HelloWorldApp {
         }
         // #endregion snippet
     }
+}
+```
+
+@tab C/C++
+
+```cpp
+#include <iostream>
+#include <vector>
+
+std::vector<int> v;
+
+#pragma region snippet
+int f() {
+  for (int item : v) std::cout << item << std::endl;
+  return v.size();
+}
+#pragma endregion snippet
+
+int main() {
+  int n, u;
+  std::cin >> n;
+  for (int i = 1; i <= n; ++i) {
+    std::cin >> u;
+    v.push_back(u);
+  }
+  std::cout << f();
+  return 0;
 }
 ```
 

--- a/docs/theme/src/zh/guide/markdown/include.md
+++ b/docs/theme/src/zh/guide/markdown/include.md
@@ -288,6 +288,8 @@ CD /D "%~dp0"
 @tab C#
 
 ```cs
+// 这是 C# 代码，“#”在 tab 名中无法显示
+
 using System;
 
 namespace HelloWorldApp {
@@ -307,6 +309,33 @@ namespace HelloWorldApp {
         }
         // #endregion snippet
     }
+}
+```
+
+@tab C/C++
+
+```cpp
+#include <iostream>
+#include <vector>
+
+std::vector<int> v;
+
+#pragma region snippet
+int f() {
+  for (int item : v) std::cout << item << std::endl;
+  return v.size();
+}
+#pragma endregion snippet
+
+int main() {
+  int n, u;
+  std::cin >> n;
+  for (int i = 1; i <= n; ++i) {
+    std::cin >> u;
+    v.push_back(u);
+  }
+  std::cout << f();
+  return 0;
 }
 ```
 


### PR DESCRIPTION
As you can see, `C#` in tab name is `C`!
This is an upstream error, I think, so I clarify it, and add the correct include syntax of C/C++.