### PR TITLE
docs(search-pro): fixed delay to searchDelay and format

### DIFF
--- a/docs/search-pro/src/zh/config.md
+++ b/docs/search-pro/src/zh/config.md
@@ -156,7 +156,7 @@ export default defineUserConfig({
 
 存储搜索结果历史的最大数量，可以设置为 `0` 以禁用。
 
-### delay
+### searchDelay
 
 - 类型: `number`
 - 默认值: `150`


### PR DESCRIPTION
更新了search-pro插件的文档

选项更新 delay -> searchDelay
将选项 sortStrategy的标题等级 2 -> 3