### PR TITLE
feat(md-enhance): 修改echarts-wordcloud的example，完善wordcloud选项

### DIFF
--- a/demo/md-enhance/src/demo/echarts.md
+++ b/demo/md-enhance/src/demo/echarts.md
@@ -749,6 +749,10 @@ const option = {
 
 ```js
 const option = {
+  // canvas background color
+  backgroundColor: "#ffa",
+  // The mouse pointer hangs to display the value
+  tooltip: {},
   series: [
     {
       type: "wordCloud",
@@ -837,12 +841,27 @@ const option = {
       },
 
       // Data is an array. Each array item must have name and value property.
+      // textStyle must not be empty
       data: [
         {
-          name: "Farrah Abraham",
-          value: 366,
+          name: "vuepress theme hope",
+          value: 8888,
           // Style of single text
-          textStyle: {},
+          //textStyle: {},
+        },
+        {
+          name: "Mr.Hope",
+          value: 10000,
+          textStyle: {
+            color: "black",
+          },
+          emphasis: {
+            textStyle: {
+              color: "#BDBEFA",
+              shadowBlur: 4,
+              shadowOffsetY: 14,
+            },
+          },
         },
       ],
     },

--- a/docs/md-enhance/src/echarts/wordcloud.snippet.md
+++ b/docs/md-enhance/src/echarts/wordcloud.snippet.md
@@ -5,6 +5,10 @@
 
 ```js
 const option = {
+  // canvas background color
+  backgroundColor: "#ffa",
+  // The mouse pointer hangs to display the value
+  tooltip: {},
   series: [
     {
       type: "wordCloud",
@@ -93,12 +97,27 @@ const option = {
       },
 
       // Data is an array. Each array item must have name and value property.
+      // textStyle must not be empty
       data: [
         {
-          name: "Farrah Abraham",
-          value: 366,
+          name: "vuepress theme hope",
+          value: 8888,
           // Style of single text
-          textStyle: {},
+          //textStyle: {},
+        },
+        {
+          name: "Mr.Hope",
+          value: 10000,
+          textStyle: {
+            color: "black",
+          },
+          emphasis: {
+            textStyle: {
+              color: "#BDBEFA",
+              shadowBlur: 4,
+              shadowOffsetY: 14,
+            },
+          },
         },
       ],
     },


### PR DESCRIPTION
关联issue https://github.com/vuepress-theme-hope/vuepress-theme-hope/issues/3372
关联pr https://github.com/vuepress-theme-hope/vuepress-theme-hope/pull/3588
- 因为data里的textStyle必须不为空所以要么写一些style要么不写这个选项。
- 完善了一些我看起来有用的选项。