### PR TITLE
修正安装markmap-toolbar命令

### DIFF
--- a/docs/md-enhance/src/zh/guide/chart/markmap.md
+++ b/docs/md-enhance/src/zh/guide/chart/markmap.md
@@ -11,26 +11,26 @@ icon: fab fa-markdown
 
 ## Settings
 
-在你的项目中安装 `markmap-lib`, `markup-toolbar` and `markmap-view`:
+在你的项目中安装 `markmap-lib`, `markmap-toolbar` and `markmap-view`:
 
 ::: code-tabs#shell
 
 @tab pnpm
 
 ```bash
-pnpm add -D markmap-lib markup-toolbar markmap-view
+pnpm add -D markmap-lib markmap-toolbar markmap-view
 ```
 
 @tab yarn
 
 ```bash
-yarn add -D markmap-lib markup-toolbar markmap-view
+yarn add -D markmap-lib markmap-toolbar markmap-view
 ```
 
 @tab npm
 
 ```bash
-npm i -D markmap-lib markup-toolbar markmap-view
+npm i -D markmap-lib markmap-toolbar markmap-view
 ```
 
 :::


### PR DESCRIPTION
原文中markmap-toolbar被错误书写为markup-toolbar