### PR TITLE
fix(comment2): fix `giscusLang` value, fix #3862

### DIFF
--- a/packages/comment2/src/client/components/Giscus.ts
+++ b/packages/comment2/src/client/components/Giscus.ts
@@ -100,7 +100,7 @@ export default defineComponent({
     const loaded = ref(false);
 
     const giscusLang = computed(() => {
-      if (SUPPORTED_LANGUAGES.includes(<GiscusLang>lang.value)) return lang;
+      if (SUPPORTED_LANGUAGES.includes(<GiscusLang>lang.value)) return lang.value;
 
       const shortCode = lang.value.split("-")[0] as GiscusLang;
 


### PR DESCRIPTION
修复评论插件中，Giscus 组件中的 计算值 `giscusLang` 错误的返回一个 `Ref` 对象