### PR TITLE
fix(utils): scrollPromise is not function

### DIFF
--- a/packages/theme/src/node/prepare/prepareBundleConfigFile.ts
+++ b/packages/theme/src/node/prepare/prepareBundleConfigFile.ts
@@ -97,7 +97,7 @@ export default defineClientConfig({
     const { scrollBehavior } = router.options;
 
     router.options.scrollBehavior = async (...args) => {
-      await scrollPromise().wait();
+      await scrollPromise.wait();
 
       return scrollBehavior(...args);
     };

--- a/packages/theme/src/node/prepare/prepareSeparatedConfigFile.ts
+++ b/packages/theme/src/node/prepare/prepareSeparatedConfigFile.ts
@@ -95,7 +95,7 @@ export default defineClientConfig({
     const { scrollBehavior } = router.options;
 
     router.options.scrollBehavior = async (...args) => {
-      await scrollPromise().wait();
+      await scrollPromise.wait();
 
       return scrollBehavior(...args);
     };


### PR DESCRIPTION
ScrollPromise is now an object, not a method, as it was missed in the previous version of commit

https://github.com/vuepress-theme-hope/vuepress-theme-hope/commit/3360a1b49eee642f72f7c75231d05de24c8bd4ab#diff-6fe11541aed36509772cdffd99af2f78be4ea140f74caf97b462304c75b1254c