### PR TITLE
fix wrong config demo

### DIFF
--- a/docs/theme/src/zh/faq/common-question.md
+++ b/docs/theme/src/zh/faq/common-question.md
@@ -102,7 +102,7 @@ export default {
   markdown: {
     headers: {
       // 用到哪一级就提取哪一级
-      levels: [2, 3, 4, 5, 6],
+      level: [2, 3, 4, 5, 6],
     },
   },
 


### PR DESCRIPTION
change `markdown.headers.levels` to `markdown.headers.level`

在本地进行调试的时候发现，F&Q里的demo code 不能正常生效，然后根据提示修复。