### PR TITLE
style: evenly space between vp-blogger-name

### DIFF
--- a/packages/theme/src/client/modules/blog/styles/blogger-info.scss
+++ b/packages/theme/src/client/modules/blog/styles/blogger-info.scss
@@ -54,12 +54,11 @@
   display: flex;
   width: 80%;
   margin: 0 auto 1rem;
+  justify-content: space-evenly;
 }
 
 .vp-blog-count {
   display: block;
-
-  width: 25%;
 
   color: inherit;
 


### PR DESCRIPTION
The original version (where 'Category' & 'Tags' look closer due to more words)

![image](https://github.com/user-attachments/assets/74e12e37-b772-4577-9e9b-46030a48bd71)

Here is a nicer version:
![image](https://github.com/user-attachments/assets/9f35c4f4-8909-4e5e-ba32-be019b03c9d7)
![image](https://github.com/user-attachments/assets/bebaaff9-9656-40d4-8157-299c6c9d422a)

