### PR TITLE
fix(theme): fix the height collapse of media-icon image under nav-screen

### DIFF
--- a/packages/theme/src/client/modules/navbar/styles/nav-screen.scss
+++ b/packages/theme/src/client/modules/navbar/styles/nav-screen.scss
@@ -39,8 +39,7 @@
   }
 
   img.icon {
-    vertical-align: -0.125em;
-    height: 1em;
+    vertical-align: middle; 
   }
 }
 


### PR DESCRIPTION
fix #4584 