### PR TITLE
fix(theme): fix pageInfo not displaying when not configured, close #4772

### DIFF
--- a/packages/theme/src/client/components/PageTitle.ts
+++ b/packages/theme/src/client/components/PageTitle.ts
@@ -28,7 +28,7 @@ export default defineComponent({
         ]),
         h(PageInfo, {
           info: info.value,
-          items: items.value,
+          items: items.value ?? undefined,
         }),
         h("hr"),
       ]);


### PR DESCRIPTION
#4772 