### PR TITLE
fix(blog): fix blog common page padding incorrect problem

### DIFF
--- a/packages/theme/src/client/components/blog/BlogMainLayout.ts
+++ b/packages/theme/src/client/components/blog/BlogMainLayout.ts
@@ -39,7 +39,7 @@ export default defineComponent({
       h(SkipLink),
       h(
         MainLayout,
-        { noToc: true },
+        { noSidebar:true, noToc: true },
         {
           ...slots,
           navScreenBottom: () =>


### PR DESCRIPTION
https://github.com/vuepress-theme-hope/vuepress-theme-hope/issues/4960

- BlogMainLayout add noSidebar props, and MainLayout will set css class to render correct padding

